### PR TITLE
1.0.3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ private fun getLocalProperties(): Properties? {
 
 val currentLocalProperties = getLocalProperties()
 
-val tagName = "1.0.2"
-val tagCode = 102
+val tagName = "1.0.3"
+val tagCode = 103
 
 android {
     namespace = "com.kieronquinn.app.pcs"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -77,6 +77,8 @@
     <queries>
         <package android:name="com.google.android.apps.pixel.psi"/>
         <package android:name="com.google.android.dialer"/>
+        <package android:name="com.google.android.as"/>
+        <package android:name="com.google.android.aicore"/>
     </queries>
 
 </manifest>

--- a/app/src/main/java/com/kieronquinn/app/pcs/PcsApplication.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/PcsApplication.kt
@@ -48,6 +48,8 @@ class PcsApplication: Application() {
         const val PACKAGE_NAME_PHONE = "com.google.android.dialer"
         const val PACKAGE_NAME_PSI = "com.google.android.apps.pixel.psi"
         const val PACKAGE_NAME_TTS = "com.google.android.tts"
+        const val PACKAGE_NAME_AS = "com.google.android.as"
+        const val PACKAGE_NAME_AIC = "com.google.android.aicore"
     }
 
     override fun onCreate() {
@@ -67,7 +69,7 @@ class PcsApplication: Application() {
         single<ManifestRepository>(createdAtStart = true) {
             ManifestRepositoryImpl(get(), get(), get())
         }
-        single<DeviceConfigPropertiesRepository> { DeviceConfigPropertiesRepositoryImpl() }
+        single<DeviceConfigPropertiesRepository> { DeviceConfigPropertiesRepositoryImpl(get()) }
         single<PhenotypeRepository>(createdAtStart = true) {
             PhenotypeRepositoryImpl(get())
         }
@@ -92,7 +94,7 @@ class PcsApplication: Application() {
         viewModel<BaseUrlDialogViewModel> { BaseUrlDialogViewModelImpl(get(), get()) }
         viewModel<BuildLabelViewModel> { BuildLabelViewModelImpl(get()) }
         viewModel<SettingsViewModel> { SettingsViewModelImpl(get(), get(), get(), get(), get(), get(), get(), get()) }
-        viewModel<ExperimentsViewModel> { ExperimentsViewModelImpl(get(), get(), get(), get()) }
+        viewModel<ExperimentsViewModel> { ExperimentsViewModelImpl(get(), get(), get(), get(), get()) }
     }
 
     private fun getRetrofit() = Retrofit.Builder()

--- a/app/src/main/java/com/kieronquinn/app/pcs/grpc/ProtectedDownloadGrpcService.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/grpc/ProtectedDownloadGrpcService.kt
@@ -10,12 +10,15 @@ import com.google.android.`as`.oss.pd.manifest.api.proto.ProtectedDownloadServic
 import com.google.crypto.tink.HybridEncrypt
 import com.google.crypto.tink.RegistryConfiguration
 import com.google.protobuf.ByteString
+import com.kieronquinn.app.pcs.model.ClientGroupOverride
 import com.kieronquinn.app.pcs.model.PcsClient
 import com.kieronquinn.app.pcs.providers.ConfigProvider
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.DEBUG_PROPERTY_NAME
+import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.PSI_CLIENT_GROUP_OVERRIDE_PROPERTY_NAME
 import com.kieronquinn.app.pcs.repositories.ManifestRepository
 import com.kieronquinn.app.pcs.repositories.PhenotypeRepositoryImpl.Companion.FLAG_REPOSITORY
 import com.kieronquinn.app.pcs.utils.extensions.DeviceConfig_getString
+import com.kieronquinn.app.pcs.utils.extensions.SystemProperties_get
 import com.kieronquinn.app.pcs.utils.extensions.SystemProperties_getBoolean
 import com.kieronquinn.app.pcs.utils.extensions.buildId
 import com.kieronquinn.app.pcs.utils.extensions.client
@@ -42,6 +45,10 @@ import org.koin.core.component.inject
 class ProtectedDownloadGrpcService(
     private val context: Context
 ): ProtectedDownloadServiceGrpc.ProtectedDownloadServiceImplBase(), KoinComponent {
+    
+    companion object {
+        private const val TAG = "AstreaService"
+    }
 
     private val scope = MainScope()
     private val manifestRepository by inject<ManifestRepository>()
@@ -79,7 +86,10 @@ class ProtectedDownloadGrpcService(
                 responseObserver.onError(Throwable())
                 return@launch
             }
-            val manifest = manifestRepository.getManifest(url, request)
+            val clientGroupOverride = ClientGroupOverride.from(
+                SystemProperties_get(PSI_CLIENT_GROUP_OVERRIDE_PROPERTY_NAME)
+            ).clientGroup
+            val manifest = manifestRepository.getManifest(url, request, clientGroupOverride)
             responseObserver.sendBackManifest(
                 manifest,
                 request.constraints.clientId,
@@ -143,6 +153,8 @@ class ProtectedDownloadGrpcService(
             Log.e("AstreaServiceError", "No suitable manifest found for $clientId")
             onError(Throwable())
             return
+        } else {
+            Log.d(TAG, "Sending back manifest for $clientId")
         }
         val key = cryptoKeys.publicKey.toByteArray().toKeysetHandle()
         val encrypted = key.getPrimitive(
@@ -171,38 +183,38 @@ class ProtectedDownloadGrpcService(
 
     @Synchronized
     private fun GetManifestConfigRequest.logAiCore() {
-        Log.d("AstreaService", "==== Get Manifest Config Request (AICore) ====")
-        Log.d("AstreaService", "Device tier: ${constraints.deviceTier}")
-        Log.d("AstreaService", "Client: ${constraints.client}")
-        Log.d("AstreaService", "Client Group: ${constraints.clientGroup}")
-        Log.d("AstreaService", "Client Version: ${constraints.clientVersion.version}")
-        Log.d("AstreaService", "Variant: ${constraints.variant}")
-        Log.d("AstreaService", "Build ID: ${constraints.buildId}")
-        Log.d("AstreaService", "Compress: ${manifestTransform.compressManifest}")
-        Log.d("AstreaService", "==== End Manifest Config Request ====")
+        Log.d(TAG, "==== Get Manifest Config Request (AICore) ====")
+        Log.d(TAG, "Device tier: ${constraints.deviceTier}")
+        Log.d(TAG, "Client: ${constraints.client}")
+        Log.d(TAG, "Client Group: ${constraints.clientGroup}")
+        Log.d(TAG, "Client Version: ${constraints.clientVersion.version}")
+        Log.d(TAG, "Variant: ${constraints.variant}")
+        Log.d(TAG, "Build ID: ${constraints.buildId}")
+        Log.d(TAG, "Compress: ${manifestTransform.compressManifest}")
+        Log.d(TAG, "==== End Manifest Config Request ====")
     }
 
     @Synchronized
     private fun GetManifestConfigRequest.logPhone() {
-        Log.d("AstreaService", "==== Get Manifest Config Request (Phone) ====")
-        Log.d("AstreaService", "Client ID: ${constraints.clientId}")
-        Log.d("AstreaService", "Client Version: ${constraints.clientVersion.version}")
-        Log.d("AstreaService", "Country: ${constraints.country}")
-        Log.d("AstreaService", "Version: ${constraints.version}")
-        Log.d("AstreaService", "Compress: ${manifestTransform.compressManifest}")
-        Log.d("AstreaService", "==== End Manifest Config Request ====")
+        Log.d(TAG, "==== Get Manifest Config Request (Phone) ====")
+        Log.d(TAG, "Client ID: ${constraints.clientId}")
+        Log.d(TAG, "Client Version: ${constraints.clientVersion.version}")
+        Log.d(TAG, "Country: ${constraints.country}")
+        Log.d(TAG, "Version: ${constraints.version}")
+        Log.d(TAG, "Compress: ${manifestTransform.compressManifest}")
+        Log.d(TAG, "==== End Manifest Config Request ====")
     }
 
     @Synchronized
     private fun GetManifestConfigRequest.logTts() {
-        Log.d("AstreaService", "==== Get Manifest Config Request (TTS) ====")
-        Log.d("AstreaService", "Client ID: ${constraints.clientId}")
-        Log.d("AstreaService", "Client Version: ${constraints.clientVersion.version}")
-        Log.d("AstreaService", "Device Model: ${constraints.deviceModel}")
-        Log.d("AstreaService", "Model Type: ${constraints.modelType}")
-        Log.d("AstreaService", "Build ID: ${constraints.buildId}")
-        Log.d("AstreaService", "Compress: ${manifestTransform.compressManifest}")
-        Log.d("AstreaService", "==== End Manifest Config Request ====")
+        Log.d(TAG, "==== Get Manifest Config Request (TTS) ====")
+        Log.d(TAG, "Client ID: ${constraints.clientId}")
+        Log.d(TAG, "Client Version: ${constraints.clientVersion.version}")
+        Log.d(TAG, "Device Model: ${constraints.deviceModel}")
+        Log.d(TAG, "Model Type: ${constraints.modelType}")
+        Log.d(TAG, "Build ID: ${constraints.buildId}")
+        Log.d(TAG, "Compress: ${manifestTransform.compressManifest}")
+        Log.d(TAG, "==== End Manifest Config Request ====")
     }
 
     private enum class RequestType {

--- a/app/src/main/java/com/kieronquinn/app/pcs/model/ClientGroupOverride.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/model/ClientGroupOverride.kt
@@ -1,0 +1,20 @@
+package com.kieronquinn.app.pcs.model
+
+import androidx.annotation.StringRes
+import com.google.android.`as`.oss.pd.api.proto.BlobConstraints.ClientGroup
+import com.kieronquinn.app.pcs.R
+
+enum class ClientGroupOverride(val clientGroup: ClientGroup?, @StringRes val title: Int) {
+    DISABLED(null, R.string.client_group_override_disabled),
+    ALL(ClientGroup.ALL, R.string.client_group_override_all),
+    ALPHA(ClientGroup.ALPHA, R.string.client_group_override_alpha),
+    BETA(ClientGroup.BETA, R.string.client_group_override_beta),
+    THIRD_PARTY_EAP(ClientGroup.THIRD_PARTY_EAP, R.string.client_group_override_third_party_eap),
+    THIRD_PARTY_EXPERIMENTAL(ClientGroup.THIRD_PARTY_EXPERIMENTAL, R.string.client_group_override_third_party_experiental);
+
+    companion object {
+        fun from(value: String?): ClientGroupOverride {
+            return entries.firstOrNull { it.name == value } ?: DISABLED
+        }
+    }
+}

--- a/app/src/main/java/com/kieronquinn/app/pcs/model/phone/PhoneFlag.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/model/phone/PhoneFlag.kt
@@ -28,6 +28,7 @@ enum class PhoneFlag(val flagPackage: FlagPackage, val flag: String) {
     ATLAS_ENABLED(FlagPackage.DIALER_DIRECTBOOT, "45413174"),
     BEESLY_ENABLED(FlagPackage.DIALER_DIRECTBOOT, "45629794"),
     BEESLY_ACTIONS_ENABLED(FlagPackage.DIALER_DIRECTBOOT, "45684179"),
+    BEESLY_GREETING_ENABLED(FlagPackage.DIALER_DIRECTBOOT, "45722860"),
     NAUTILUS_ENABLED(FlagPackage.DIALER_DIRECTBOOT, "45665235"),
     SONIC_ENABLED(FlagPackage.DIALER_DIRECTBOOT, "45408594"),
     XATU_ENABLED(FlagPackage.DIALER_DIRECTBOOT, "45417169"),
@@ -43,6 +44,7 @@ enum class PhoneFlag(val flagPackage: FlagPackage, val flag: String) {
     CALL_RECORDING_ENABLED(FlagPackage.DIALER, "G__enable_call_recording"),
     CALL_RECORDING_FORCE_OVERRIDE_ENABLED(FlagPackage.DIALER, "G__force_within_call_recording_geofence_value"),
     CALL_RECORDING_CROSBY_ENABLED(FlagPackage.DIALER, "G__force_within_crosby_geofence_value"),
+    CALL_RECORDING_FERMAT_DISABLE(FlagPackage.DIALER_DIRECTBOOT, "45730953"),
     ;
 
     companion object {

--- a/app/src/main/java/com/kieronquinn/app/pcs/repositories/BaseSettingsRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/repositories/BaseSettingsRepository.kt
@@ -141,15 +141,16 @@ abstract class BaseSettingsRepositoryImpl: BaseSettingsRepository {
         }
     }
 
+    @Suppress("UNNECESSARY_SAFE_CALL")
     private val onPrefsChange = callbackFlow {
-        sharedPreferences.registerOnSharedPreferenceChangeListener(listener)
+        sharedPreferences?.registerOnSharedPreferenceChangeListener(listener)
         launch {
             onKeyChanged.collect { key ->
                 trySend(key)
             }
         }
         awaitClose {
-            sharedPreferences.unregisterOnSharedPreferenceChangeListener(listener)
+            sharedPreferences?.unregisterOnSharedPreferenceChangeListener(listener)
         }
     }.shareIn(scope, SharingStarted.Eagerly)
 

--- a/app/src/main/java/com/kieronquinn/app/pcs/repositories/DeviceConfigPropertiesRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/repositories/DeviceConfigPropertiesRepository.kt
@@ -1,10 +1,13 @@
 package com.kieronquinn.app.pcs.repositories
 
+import android.content.Context
+import android.content.pm.PackageManager
 import android.util.Base64
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.DeviceConfigEntry
 import com.topjohnwu.superuser.Shell
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.File
 
 /**
  *  Uses libsu to get/override/clear DeviceConfig and SystemProperties entries. Due to the backend
@@ -16,11 +19,12 @@ interface DeviceConfigPropertiesRepository {
 
     companion object {
         const val DEBUG_PROPERTY_NAME = "persist.pcs.debug"
-        const val PHONE_FLAGS_PROPERTY_NAME = "persist.pcs.enabled_phone_flags"
         const val PSI_ENABLE_APPS_PROPERTY_NAME = "persist.psi.enable_apps"
         const val PSI_FORCE_ACCOUNT_PRESENCE_PROPERTY_NAME = "persist.psi.force_account_presence"
         const val PSI_FORCE_ACCOUNT_TYPE_PROPERTY_NAME = "persist.psi.force_account_type"
         const val PSI_FORCE_ADMIN_ALLOWANCE_PROPERTY_NAME = "persist.psi.force_admin_allowance"
+        const val PSI_CLIENT_GROUP_OVERRIDE_PROPERTY_NAME = "persist.psi.client_group_override"
+        const val AS_SHOW_NOW_PLAYING_NOTIFICATION = "persist.as.show_now_playing_notification"
     }
 
     /**
@@ -56,6 +60,11 @@ interface DeviceConfigPropertiesRepository {
      */
     suspend fun forceStopPackage(packageName: String)
 
+    /**
+     *  Deletes MDD-related shared prefs for a package to force a redownload of manifests
+     */
+    suspend fun clearMdd(packageName: String)
+
     data class DeviceConfigEntry(
         val namespace: String,
         val flag: String,
@@ -74,7 +83,7 @@ interface DeviceConfigPropertiesRepository {
 
 }
 
-class DeviceConfigPropertiesRepositoryImpl : DeviceConfigPropertiesRepository {
+class DeviceConfigPropertiesRepositoryImpl(context: Context) : DeviceConfigPropertiesRepository {
 
     companion object {
         private const val LIST = "device_config list"
@@ -84,10 +93,11 @@ class DeviceConfigPropertiesRepositoryImpl : DeviceConfigPropertiesRepository {
     }
 
     private var _shell: Shell? = null
+    private val packageManager = context.packageManager
 
     private val shell
         get() = _shell ?: run {
-            Shell.Builder.create().build().also {
+            Shell.Builder.create().setFlags(Shell.FLAG_MOUNT_MASTER).build().also {
                 _shell = it
             }
         }
@@ -143,6 +153,19 @@ class DeviceConfigPropertiesRepositoryImpl : DeviceConfigPropertiesRepository {
     override suspend fun forceStopPackage(packageName: String) {
         withContext(Dispatchers.IO) {
             shell.newJob().add("am force-stop $packageName").exec()
+        }
+    }
+
+    override suspend fun clearMdd(packageName: String) {
+        withContext(Dispatchers.IO) {
+            val sharedPrefsDir = try {
+                val dataDir = packageManager.getApplicationInfo(packageName, 0).dataDir
+                File(dataDir, "shared_prefs")
+            } catch (e: PackageManager.NameNotFoundException) {
+                return@withContext
+            }
+            shell.newJob().add("rm ${sharedPrefsDir.absolutePath}/gms_icing_mdd_*.xml").exec()
+            forceStopPackage(packageName)
         }
     }
 

--- a/app/src/main/java/com/kieronquinn/app/pcs/repositories/ManifestRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/repositories/ManifestRepository.kt
@@ -2,6 +2,7 @@ package com.kieronquinn.app.pcs.repositories
 
 import android.content.Context
 import com.google.android.`as`.oss.pd.api.proto.BlobConstraints
+import com.google.android.`as`.oss.pd.api.proto.BlobConstraints.ClientGroup
 import com.google.android.`as`.oss.pd.manifest.api.proto.GetManifestConfigRequest
 import com.google.android.`as`.oss.pd.manifest.api.proto.ManifestConfigConstraints
 import com.google.crypto.tink.KeysetHandle
@@ -13,6 +14,7 @@ import com.kieronquinn.app.pcs.repositories.PhenotypeRepository.PhenotypeState
 import com.kieronquinn.app.pcs.service.ManifestService
 import com.kieronquinn.app.pcs.utils.extensions.buildId
 import com.kieronquinn.app.pcs.utils.extensions.client
+import com.kieronquinn.app.pcs.utils.extensions.clientGroup
 import com.kieronquinn.app.pcs.utils.extensions.decryptManifest
 import com.kieronquinn.app.pcs.utils.extensions.deviceTier
 import com.kieronquinn.app.pcs.utils.extensions.getManifestKey
@@ -36,7 +38,11 @@ interface ManifestRepository {
     fun refresh()
     suspend fun refreshAndWait(): Boolean
     suspend fun checkRepositoryUrl(url: String): Boolean
-    suspend fun getManifest(url: String, request: GetManifestConfigRequest): ByteArray?
+    suspend fun getManifest(
+        url: String,
+        request: GetManifestConfigRequest,
+        clientGroupOverride: ClientGroup? = null
+    ): ByteArray?
     suspend fun getPhoneManifest(url: String, clientId: String): ByteArray?
     suspend fun getTtsManifest(url: String, id: String): ByteArray?
 
@@ -153,10 +159,30 @@ class ManifestRepositoryImpl(
         }
     }
 
-    override suspend fun getManifest(url: String, request: GetManifestConfigRequest): ByteArray? {
+    override suspend fun getManifest(
+        url: String,
+        request: GetManifestConfigRequest,
+        clientGroupOverride: ClientGroup?
+    ): ByteArray? {
         val mainManifest = getManifests(url) ?: return null
         val manifest = mainManifest.manifestList.firstOrNull {
-            request.constraints.matches(it.constraints)
+            // Ideal search: results matching either the search or the override
+            request.constraints.matches(
+                other = it.constraints,
+                clientGroupOverride = clientGroupOverride
+            )
+        } ?: mainManifest.manifestList.firstOrNull {
+            // Fallback 1: result with ALL client group (usually available)
+            request.constraints.matches(
+                other = it.constraints,
+                clientGroupFallbackToAll = true
+            )
+        } ?: mainManifest.manifestList.firstOrNull {
+            // Fallback 2: first result
+            request.constraints.matches(
+                other = it.constraints,
+                clientGroupFallbackToFirst = true
+            )
         } ?: return null
         return getManifest(url, manifest.name, manifest.encryptionKey.toByteArray().toKeysetHandle())
     }
@@ -190,15 +216,42 @@ class ManifestRepositoryImpl(
         setupUrlRefresh()
     }
 
-    /**
-     *  Checks fields we actually care about
-     */
-    private fun ManifestConfigConstraints.matches(other: BlobConstraints): Boolean {
+    private fun ManifestConfigConstraints.matches(
+        other: BlobConstraints,
+        clientGroupFallbackToAll: Boolean = false,
+        clientGroupFallbackToFirst: Boolean = false,
+        clientGroupOverride: ClientGroup? = null
+    ): Boolean {
         if (client?.client != other.client) return false
         if (variant != other.variant) return false
         if (deviceTier != other.deviceTier)  return false
+        val clientGroupMatches = clientGroup.matches(
+            other.clientGroup,
+            clientGroupFallbackToAll,
+            clientGroupFallbackToFirst,
+            clientGroupOverride
+        )
+        if (!clientGroupMatches) return false
         // Only check the build ID if it's actually specified
         return buildId == 0L || buildId == other.buildId
+    }
+
+    private fun ClientGroup?.matches(
+        other: ClientGroup,
+        fallbackToAll: Boolean,
+        fallbackToFirst: Boolean,
+        override: ClientGroup?
+    ): Boolean {
+        return when {
+            // If our group is null, we should also try to fall back to all if available
+            (this == null || fallbackToAll) && other == ClientGroup.ALL -> true
+            // If fallback to first is set, all other options have been exhausted, take first option
+            fallbackToFirst -> true
+            // If override is set, try to match it
+            override != null -> other == override
+            // Otherwise, match the request
+            else -> other == this
+        }
     }
 
 }

--- a/app/src/main/java/com/kieronquinn/app/pcs/repositories/PhenotypeRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/repositories/PhenotypeRepository.kt
@@ -6,17 +6,22 @@ import com.kieronquinn.app.pcs.model.PcsClient.BuildId.Namespace
 import com.kieronquinn.app.pcs.model.proto.Labels
 import com.kieronquinn.app.pcs.repositories.PhenotypeRepository.PhenotypeState
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
 
 interface PhenotypeRepository {
 
     val state: StateFlow<PhenotypeState?>
+    val onVersionsReset: Flow<Unit>
 
     fun refresh()
     suspend fun refreshAndWait()
     suspend fun setVersions(versions: Map<PcsClient, Long>, waitForRefresh: Boolean)
+    suspend fun resetVersions()
     suspend fun setLabels(labels: Labels)
     suspend fun resetLabels()
     suspend fun setRepository(url: String)
@@ -42,6 +47,7 @@ interface PhenotypeRepository {
 object PhenotypeRepositoryStub: PhenotypeRepository {
 
     override val state = MutableStateFlow<PhenotypeState?>(PhenotypeState.Unavailable)
+    override val onVersionsReset = emptyFlow<Unit>()
 
     override fun refresh() {
         // No-op
@@ -52,6 +58,10 @@ object PhenotypeRepositoryStub: PhenotypeRepository {
     }
 
     override suspend fun setVersions(versions: Map<PcsClient, Long>, wait: Boolean) {
+        // No-op
+    }
+
+    override suspend fun resetVersions() {
         // No-op
     }
 
@@ -81,6 +91,7 @@ class PhenotypeRepositoryImpl(
     private val scope = MainScope()
 
     override val state = MutableStateFlow<PhenotypeState?>(null)
+    override val onVersionsReset = MutableSharedFlow<Unit>()
 
     override fun refresh() {
         scope.launch {
@@ -129,6 +140,19 @@ class PhenotypeRepositoryImpl(
         } else {
             refresh()
         }
+    }
+
+    override suspend fun resetVersions() {
+        val entries = PcsClient.entries.map {
+            DeviceConfigPropertiesRepository.DeviceConfigEntry(
+                namespace = it.buildId.namespace.value,
+                flag = it.buildId.flag,
+                value = ""
+            )
+        }
+        deviceConfigPropertiesRepository.clearConfigOverrides(entries)
+        refreshAndWait()
+        onVersionsReset.emit(Unit)
     }
 
     override suspend fun setLabels(labels: Labels) {

--- a/app/src/main/java/com/kieronquinn/app/pcs/repositories/PropertiesRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/repositories/PropertiesRepository.kt
@@ -1,12 +1,16 @@
 package com.kieronquinn.app.pcs.repositories
 
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_PSI
+import com.kieronquinn.app.pcs.model.ClientGroupOverride
+import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.AS_SHOW_NOW_PLAYING_NOTIFICATION
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.DEBUG_PROPERTY_NAME
+import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.PSI_CLIENT_GROUP_OVERRIDE_PROPERTY_NAME
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.PSI_ENABLE_APPS_PROPERTY_NAME
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.PSI_FORCE_ACCOUNT_PRESENCE_PROPERTY_NAME
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.PSI_FORCE_ACCOUNT_TYPE_PROPERTY_NAME
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.PSI_FORCE_ADMIN_ALLOWANCE_PROPERTY_NAME
 import com.kieronquinn.app.pcs.repositories.PropertiesRepository.State
+import com.kieronquinn.app.pcs.utils.extensions.SystemProperties_get
 import com.kieronquinn.app.pcs.utils.extensions.SystemProperties_getBoolean
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
@@ -26,13 +30,17 @@ interface PropertiesRepository {
     suspend fun setPsiForceAccountPresence(enabled: Boolean)
     suspend fun setPsiForceAccountType(enabled: Boolean)
     suspend fun setPsiForceAdminAllowance(enabled: Boolean)
+    suspend fun setAsNowPlayingNotificationEnabled(enabled: Boolean)
+    suspend fun setClientGroupOverride(override: ClientGroupOverride)
 
     data class State(
         val debug: Boolean = false,
         val psiApps: Boolean = false,
         val psiForceAccountPresence: Boolean = false,
         val psiForceAccountType: Boolean = false,
-        val psiForceAdminAllowance: Boolean = false
+        val psiForceAdminAllowance: Boolean = false,
+        val asNowPlayingNotificationEnabled: Boolean = false,
+        val clientGroupOverride: ClientGroupOverride = ClientGroupOverride.DISABLED
     )
 
 }
@@ -75,13 +83,25 @@ class PropertiesRepositoryImpl(
         refreshBus.emit(System.currentTimeMillis())
     }
 
+    override suspend fun setAsNowPlayingNotificationEnabled(enabled: Boolean) {
+        deviceConfigPropertiesRepository.setProperty(AS_SHOW_NOW_PLAYING_NOTIFICATION, enabled.toString())
+        refreshBus.emit(System.currentTimeMillis())
+    }
+
+    override suspend fun setClientGroupOverride(override: ClientGroupOverride) {
+        deviceConfigPropertiesRepository.setProperty(PSI_CLIENT_GROUP_OVERRIDE_PROPERTY_NAME, override.name)
+        refreshBus.emit(System.currentTimeMillis())
+    }
+
     private fun getState(): State {
         return State(
             SystemProperties_getBoolean(DEBUG_PROPERTY_NAME, false),
             SystemProperties_getBoolean(PSI_ENABLE_APPS_PROPERTY_NAME, false),
             SystemProperties_getBoolean(PSI_FORCE_ACCOUNT_PRESENCE_PROPERTY_NAME, false),
             SystemProperties_getBoolean(PSI_FORCE_ACCOUNT_TYPE_PROPERTY_NAME, false),
-            SystemProperties_getBoolean(PSI_FORCE_ADMIN_ALLOWANCE_PROPERTY_NAME, false)
+            SystemProperties_getBoolean(PSI_FORCE_ADMIN_ALLOWANCE_PROPERTY_NAME, false),
+            SystemProperties_getBoolean(AS_SHOW_NOW_PLAYING_NOTIFICATION, false),
+            ClientGroupOverride.from(SystemProperties_get(PSI_CLIENT_GROUP_OVERRIDE_PROPERTY_NAME))
         )
     }
 

--- a/app/src/main/java/com/kieronquinn/app/pcs/ui/screens/experiments/ExperimentsScreen.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/ui/screens/experiments/ExperimentsScreen.kt
@@ -1,6 +1,8 @@
 package com.kieronquinn.app.pcs.ui.screens.experiments
 
+import android.content.Context
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,23 +13,27 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kieronquinn.app.pcs.R
+import com.kieronquinn.app.pcs.model.ClientGroupOverride
 import com.kieronquinn.app.pcs.model.phone.PhoneSettings
 import com.kieronquinn.app.pcs.repositories.PropertiesRepository
 import com.kieronquinn.app.pcs.repositories.SettingsRepository.BeeslyRegion
 import com.kieronquinn.app.pcs.repositories.SettingsRepository.DobbyRegion
 import com.kieronquinn.app.pcs.repositories.SettingsRepository.PatrickPhase
 import com.kieronquinn.app.pcs.ui.components.InfoCard
+import com.kieronquinn.app.pcs.ui.screens.experiments.ExperimentsViewModel.Event
 import com.kieronquinn.app.pcs.ui.screens.experiments.ExperimentsViewModel.State
 import com.kieronquinn.app.pcs.ui.screens.loading.LoadingScreen
 import com.kieronquinn.app.pcs.ui.theme.PcsTheme
@@ -36,6 +42,7 @@ import com.kieronquinn.app.pcs.utils.extensions.listPreference
 import com.kieronquinn.app.pcs.utils.extensions.switchPreference
 import com.kieronquinn.app.pcs.utils.extensions.textResource
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
+import me.zhanghai.compose.preference.preference
 import me.zhanghai.compose.preference.preferenceCategory
 import org.koin.androidx.compose.koinViewModel
 import uk.co.bocajsolutions.cardshape.Shape
@@ -58,7 +65,11 @@ private data class Interactions(
     val onPsiAppsChanged: (Boolean) -> Unit,
     val onPsiForceAccountPresenceChanged: (Boolean) -> Unit,
     val onPsiForceAccountTypeChanged: (Boolean) -> Unit,
-    val onPsiForceAdminAllowanceChanged: (Boolean) -> Unit
+    val onPsiForceAdminAllowanceChanged: (Boolean) -> Unit,
+    val onAsNowPlayingChanged: (Boolean) -> Unit,
+    val onClearMddClicked: () -> Unit,
+    val onClearOverridesClicked: () -> Unit,
+    val onClientGroupOverrideChanged: (ClientGroupOverride) -> Unit,
 ) {
     companion object {
         val PREVIEW = Interactions(
@@ -79,7 +90,11 @@ private data class Interactions(
             onPsiAppsChanged = {},
             onPsiForceAccountPresenceChanged = {},
             onPsiForceAccountTypeChanged = {},
-            onPsiForceAdminAllowanceChanged = {}
+            onPsiForceAdminAllowanceChanged = {},
+            onAsNowPlayingChanged = {},
+            onClearMddClicked = {},
+            onClearOverridesClicked = {},
+            onClientGroupOverrideChanged = {}
         )
     }
 }
@@ -106,7 +121,11 @@ fun ExperimentsScreen() = ProvidePreferenceLocals {
         onPsiAppsChanged = viewModel::onPsiAppsChanged,
         onPsiForceAccountPresenceChanged = viewModel::onPsiForceAccountPresenceChanged,
         onPsiForceAccountTypeChanged = viewModel::onPsiForceAccountTypeChanged,
-        onPsiForceAdminAllowanceChanged = viewModel::onPsiForceAdminAllowanceChanged
+        onPsiForceAdminAllowanceChanged = viewModel::onPsiForceAdminAllowanceChanged,
+        onAsNowPlayingChanged = viewModel::onAsNowPlayingChanged,
+        onClearMddClicked = viewModel::onClearMddClicked,
+        onClearOverridesClicked = viewModel::onClearOverridesClicked,
+        onClientGroupOverrideChanged = viewModel::onClientGroupOverrideChanged
     )
     when (state) {
         State.Loading -> LoadingContent()
@@ -114,6 +133,23 @@ fun ExperimentsScreen() = ProvidePreferenceLocals {
             state as State.Loaded,
             interactions
         )
+    }
+    val context = LocalContext.current
+    LaunchedEffect(Unit) {
+        viewModel.events.collect {
+            handleEvent(context, it)
+        }
+    }
+}
+
+private fun handleEvent(context: Context, event: Event) {
+    when (event) {
+        Event.MANIFESTS_PURGED -> {
+            Toast.makeText(context, R.string.screen_experiments_clear_mdd_toast, Toast.LENGTH_LONG).show()
+        }
+        Event.MANIFEST_OVERRIDES_CLEARED -> {
+            Toast.makeText(context, R.string.screen_experiments_clear_overrides_toast, Toast.LENGTH_LONG).show()
+        }
     }
 }
 
@@ -141,89 +177,411 @@ private fun LoadedContent(state: State.Loaded, interactions: Interactions) {
             )
         }
 
-        preferenceCategory(
-            key = "category_phone",
-            title = {
-                Text(stringResource(R.string.screen_experiments_category_google_phone))
-            }
-        )
-
-        val phoneFlagsCount = 11
-        val sharpieShape = Shape(phoneFlagsCount, 0)
-        switchPreference(
-            modifier = Modifier
-                .padding(horizontal = 8.dp)
-                .background(color = surface, shape = sharpieShape)
-                .clip(sharpieShape),
-            value = state.phoneSettings.sharpieEnabled,
-            key = "phone_flags_sharpie",
-            title = { _ ->
-                Text(
-                    text = stringResource(R.string.screen_experiments_phone_feature_sharpie),
-                    style = MaterialTheme.typography.bodyLarge
-                )
-            },
-            summary = { _ ->
-                val title = stringResource(R.string.screen_experiments_phone_feature_sharpie)
-                Text(text = stringResource(R.string.screen_experiments_phone_subtitle, title))
-            },
-            onValueChange = {
-                interactions.onPhoneSharpieEnabledChanged(it)
-            }
-        )
-
-        item {
-            Spacer(Modifier.height(2.dp))
-        }
-
-        val dobbyShape = Shape(phoneFlagsCount, 1)
-        val dobbyDisabled = state.phoneSettings.dobbyUrl.isNullOrBlank()
-                || state.phoneSettings.dobbyDuplexFiles.isNullOrBlank()
-        val dobbyEnabled = state.phoneSettings.dobbyEnabled && !dobbyDisabled
-        switchPreference(
-            modifier = Modifier
-                .padding(horizontal = 8.dp)
-                .background(color = surface, shape = dobbyShape)
-                .clip(dobbyShape),
-            value = dobbyEnabled,
-            enabled = { !dobbyDisabled },
-            key = "phone_flags_dobby",
-            title = { _ ->
-                Text(
-                    text = stringResource(R.string.screen_experiments_phone_feature_dobby),
-                    style = MaterialTheme.typography.bodyLarge
-                )
-            },
-            summary = { _ ->
-                if (!dobbyDisabled) {
-                    val title = stringResource(R.string.screen_experiments_phone_feature_dobby)
-                    Text(text = stringResource(R.string.screen_experiments_phone_subtitle, title))
-                } else {
-                    Text(text = stringResource(R.string.screen_experiments_phone_feature_disabled))
+        if (state.phoneAvailable) {
+            preferenceCategory(
+                key = "category_phone",
+                title = {
+                    Text(stringResource(R.string.screen_experiments_category_google_phone))
                 }
-            },
-            onValueChange = {
-                interactions.onPhoneDobbyEnabledChanged(it)
-            }
-        )
+            )
 
-        item {
-            Spacer(Modifier.height(2.dp))
-        }
-        
-        if (dobbyEnabled) {
-            val dobbyRegionShape = Shape(phoneFlagsCount, 1)
+            val phoneFlagsCount = 11
+            val sharpieShape = Shape(phoneFlagsCount, 0)
+            switchPreference(
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .background(color = surface, shape = sharpieShape)
+                    .clip(sharpieShape),
+                value = state.phoneSettings.sharpieEnabled,
+                key = "phone_flags_sharpie",
+                title = { _ ->
+                    Text(
+                        text = stringResource(R.string.screen_experiments_phone_feature_sharpie),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                },
+                summary = { _ ->
+                    val title = stringResource(R.string.screen_experiments_phone_feature_sharpie)
+                    Text(text = stringResource(R.string.screen_experiments_phone_subtitle, title))
+                },
+                onValueChange = {
+                    interactions.onPhoneSharpieEnabledChanged(it)
+                }
+            )
+
+            item {
+                Spacer(Modifier.height(2.dp))
+            }
+
+            val dobbyShape = Shape(phoneFlagsCount, 1)
+            val dobbyDisabled = state.phoneSettings.dobbyUrl.isNullOrBlank()
+                    || state.phoneSettings.dobbyDuplexFiles.isNullOrBlank()
+            val dobbyEnabled = state.phoneSettings.dobbyEnabled && !dobbyDisabled
+            switchPreference(
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .background(color = surface, shape = dobbyShape)
+                    .clip(dobbyShape),
+                value = dobbyEnabled,
+                enabled = { !dobbyDisabled },
+                key = "phone_flags_dobby",
+                title = { _ ->
+                    Text(
+                        text = stringResource(R.string.screen_experiments_phone_feature_dobby),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                },
+                summary = { _ ->
+                    if (!dobbyDisabled) {
+                        val title = stringResource(R.string.screen_experiments_phone_feature_dobby)
+                        Text(
+                            text = stringResource(
+                                R.string.screen_experiments_phone_subtitle,
+                                title
+                            )
+                        )
+                    } else {
+                        Text(text = stringResource(R.string.screen_experiments_phone_feature_disabled))
+                    }
+                },
+                onValueChange = {
+                    interactions.onPhoneDobbyEnabledChanged(it)
+                }
+            )
+
+            item {
+                Spacer(Modifier.height(2.dp))
+            }
+
+            if (dobbyEnabled) {
+                val dobbyRegionShape = Shape(phoneFlagsCount, 1)
+                listPreference(
+                    modifier = Modifier
+                        .padding(horizontal = 8.dp)
+                        .background(color = surface, shape = dobbyRegionShape)
+                        .clip(dobbyRegionShape),
+                    value = state.phoneSettings.dobbyRegion,
+                    values = DobbyRegion.entries,
+                    key = "phone_flags_dobby_region",
+                    title = { _ ->
+                        Text(
+                            text = stringResource(R.string.screen_experiments_phone_feature_dobby_region),
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                    },
+                    valueToText = {
+                        AnnotatedString(resources.getString(it.label))
+                    },
+                    summary = {
+                        Text(text = stringResource(it.label))
+                    },
+                    onValueChange = {
+                        interactions.onPhoneDobbyRegionChanged(it)
+                    }
+                )
+
+                item {
+                    Spacer(Modifier.height(2.dp))
+                }
+            }
+
+            val atlasShape = Shape(phoneFlagsCount, 2)
+            val atlasDisabled = state.phoneSettings.atlasModels.isNullOrBlank()
+            val atlasEnabled = state.phoneSettings.atlasEnabled && !atlasDisabled
+            switchPreference(
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .background(color = surface, shape = atlasShape)
+                    .clip(atlasShape),
+                value = atlasEnabled,
+                enabled = { !atlasDisabled },
+                key = "phone_flags_atlas",
+                title = { _ ->
+                    Text(
+                        text = stringResource(R.string.screen_experiments_phone_feature_atlas),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                },
+                summary = { _ ->
+                    if (!atlasDisabled) {
+                        val title = stringResource(R.string.screen_experiments_phone_feature_atlas)
+                        Text(
+                            text = stringResource(
+                                R.string.screen_experiments_phone_subtitle,
+                                title
+                            )
+                        )
+                    } else {
+                        Text(text = stringResource(R.string.screen_experiments_phone_feature_disabled))
+                    }
+                },
+                onValueChange = {
+                    interactions.onPhoneAtlasEnabledChanged(it)
+                }
+            )
+
+            item {
+                Spacer(Modifier.height(2.dp))
+            }
+
+            val beeslyShape = Shape(phoneFlagsCount, 3)
+            val beeslyDisabled = state.phoneSettings.beesly.isNullOrBlank()
+            val beeslyEnabled = state.phoneSettings.beeslyEnabled && !beeslyDisabled
+            switchPreference(
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .background(color = surface, shape = beeslyShape)
+                    .clip(beeslyShape),
+                value = beeslyEnabled,
+                enabled = { !beeslyDisabled },
+                key = "phone_flags_beesly",
+                title = { _ ->
+                    Text(
+                        text = stringResource(R.string.screen_experiments_phone_feature_beesly),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                },
+                summary = { _ ->
+                    if (!beeslyDisabled) {
+                        val title = stringResource(R.string.screen_experiments_phone_feature_beesly)
+                        Text(
+                            text = stringResource(
+                                R.string.screen_experiments_phone_subtitle,
+                                title
+                            )
+                        )
+                    } else {
+                        Text(text = stringResource(R.string.screen_experiments_phone_feature_disabled))
+                    }
+                },
+                onValueChange = {
+                    interactions.onPhoneBeeslyEnabledChanged(it)
+                }
+            )
+
+            item {
+                Spacer(Modifier.height(2.dp))
+            }
+
+            if (beeslyEnabled) {
+                val beeslyRegionShape = Shape(phoneFlagsCount, 3)
+                listPreference(
+                    modifier = Modifier
+                        .padding(horizontal = 8.dp)
+                        .background(color = surface, shape = beeslyRegionShape)
+                        .clip(beeslyRegionShape),
+                    value = state.phoneSettings.beeslyRegion,
+                    values = BeeslyRegion.entries,
+                    key = "phone_flags_beesly_region",
+                    title = { _ ->
+                        Text(
+                            text = stringResource(R.string.screen_experiments_phone_feature_beesly_region),
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                    },
+                    valueToText = {
+                        AnnotatedString(resources.getString(it.label))
+                    },
+                    summary = {
+                        Text(text = stringResource(it.label))
+                    },
+                    onValueChange = {
+                        interactions.onPhoneBeeslyRegionChanged(it)
+                    }
+                )
+
+                item {
+                    Spacer(Modifier.height(2.dp))
+                }
+            }
+
+            val nautilusShape = Shape(phoneFlagsCount, 4)
+            switchPreference(
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .background(color = surface, shape = nautilusShape)
+                    .clip(nautilusShape),
+                value = state.phoneSettings.nautilusEnabled,
+                key = "phone_flags_nautilus",
+                title = { _ ->
+                    Text(
+                        text = stringResource(R.string.screen_experiments_phone_feature_nautilus),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                },
+                summary = { _ ->
+                    val title = stringResource(R.string.screen_experiments_phone_feature_nautilus)
+                    Text(text = stringResource(R.string.screen_experiments_phone_subtitle, title))
+                },
+                onValueChange = {
+                    interactions.onPhoneNautilusEnabledChanged(it)
+                }
+            )
+
+            item {
+                Spacer(Modifier.height(2.dp))
+            }
+
+            val sonicShape = Shape(phoneFlagsCount, 5)
+            switchPreference(
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .background(color = surface, shape = sonicShape)
+                    .clip(sonicShape),
+                value = state.phoneSettings.sonicEnabled,
+                key = "phone_flags_sonic",
+                title = { _ ->
+                    Text(
+                        text = stringResource(R.string.screen_experiments_phone_feature_sonic),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                },
+                summary = { _ ->
+                    val title = stringResource(R.string.screen_experiments_phone_feature_sonic)
+                    Text(text = stringResource(R.string.screen_experiments_phone_subtitle, title))
+                },
+                onValueChange = {
+                    interactions.onPhoneSonicEnabledChanged(it)
+                }
+            )
+
+            item {
+                Spacer(Modifier.height(2.dp))
+            }
+
+            val xatuShape = Shape(phoneFlagsCount, 5)
+            val xatuDisabled = state.phoneSettings.xatuModels.isNullOrBlank()
+            val xatuEnabled = state.phoneSettings.xatuEnabled && !xatuDisabled
+            switchPreference(
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .background(color = surface, shape = xatuShape)
+                    .clip(xatuShape),
+                value = xatuEnabled,
+                enabled = { !xatuDisabled },
+                key = "phone_flags_xatu",
+                title = { _ ->
+                    Text(
+                        text = stringResource(R.string.screen_experiments_phone_feature_xatu),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                },
+                summary = { _ ->
+                    if (!xatuDisabled) {
+                        val title = stringResource(R.string.screen_experiments_phone_feature_xatu)
+                        Text(
+                            text = stringResource(
+                                R.string.screen_experiments_phone_subtitle,
+                                title
+                            )
+                        )
+                    } else {
+                        Text(text = stringResource(R.string.screen_experiments_phone_feature_disabled))
+                    }
+                },
+                onValueChange = {
+                    interactions.onPhoneXatuEnabledChanged(it)
+                }
+            )
+
+            item {
+                Spacer(Modifier.height(2.dp))
+            }
+
+            val callerTagsShape = Shape(phoneFlagsCount, 6)
+            switchPreference(
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .background(color = surface, shape = callerTagsShape)
+                    .clip(callerTagsShape),
+                value = state.phoneSettings.callerTagsEnabled,
+                key = "phone_flags_caller_tags",
+                title = { _ ->
+                    Text(
+                        text = stringResource(R.string.screen_experiments_phone_feature_caller_tags),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                },
+                summary = { _ ->
+                    val title =
+                        stringResource(R.string.screen_experiments_phone_feature_caller_tags)
+                    Text(text = stringResource(R.string.screen_experiments_phone_subtitle, title))
+                },
+                onValueChange = {
+                    interactions.onPhoneCallerTagsEnabledChanged(it)
+                }
+            )
+
+            item {
+                Spacer(Modifier.height(2.dp))
+            }
+
+            val fermatShape = Shape(phoneFlagsCount, 7)
+            switchPreference(
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .background(color = surface, shape = fermatShape)
+                    .clip(fermatShape),
+                value = state.phoneSettings.fermatEnabled,
+                key = "phone_flags_fermat",
+                title = { _ ->
+                    Text(
+                        text = stringResource(R.string.screen_experiments_phone_feature_fermat),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                },
+                summary = { _ ->
+                    val title = stringResource(R.string.screen_experiments_phone_feature_fermat)
+                    Text(text = stringResource(R.string.screen_experiments_phone_subtitle, title))
+                },
+                onValueChange = {
+                    interactions.onPhoneFermatEnabledChanged(it)
+                }
+            )
+
+            item {
+                Spacer(Modifier.height(2.dp))
+            }
+
+            val expressiveShape = Shape(phoneFlagsCount, 8)
+            switchPreference(
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .background(color = surface, shape = expressiveShape)
+                    .clip(expressiveShape),
+                value = state.phoneSettings.expressoEnabled,
+                key = "phone_flags_expresso",
+                title = { _ ->
+                    Text(
+                        text = stringResource(R.string.screen_experiments_phone_feature_expresso),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                },
+                summary = { _ ->
+                    val title = stringResource(R.string.screen_experiments_phone_feature_expresso)
+                    Text(text = stringResource(R.string.screen_experiments_phone_subtitle, title))
+                },
+                onValueChange = {
+                    interactions.onPhoneExpressoEnabledChanged(it)
+                }
+            )
+
+            item {
+                Spacer(Modifier.height(2.dp))
+            }
+
+            val patrickShape = Shape(phoneFlagsCount, 9)
             listPreference(
                 modifier = Modifier
                     .padding(horizontal = 8.dp)
-                    .background(color = surface, shape = dobbyRegionShape)
-                    .clip(dobbyRegionShape),
-                value = state.phoneSettings.dobbyRegion,
-                values = DobbyRegion.entries,
-                key = "phone_flags_dobby_region",
+                    .background(color = surface, shape = patrickShape)
+                    .clip(patrickShape),
+                value = state.phoneSettings.patrickPhase,
+                values = PatrickPhase.entries,
+                key = "phone_flags_patrick",
                 title = { _ ->
                     Text(
-                        text = stringResource(R.string.screen_experiments_phone_feature_dobby_region),
+                        text = stringResource(R.string.screen_experiments_phone_feature_patrick),
                         style = MaterialTheme.typography.bodyLarge
                     )
                 },
@@ -234,336 +592,38 @@ private fun LoadedContent(state: State.Loaded, interactions: Interactions) {
                     Text(text = stringResource(it.label))
                 },
                 onValueChange = {
-                    interactions.onPhoneDobbyRegionChanged(it)
+                    interactions.onPhonePatrickChanged(it)
                 }
             )
 
             item {
                 Spacer(Modifier.height(2.dp))
             }
-        }
 
-        val atlasShape = Shape(phoneFlagsCount, 2)
-        val atlasDisabled = state.phoneSettings.atlasModels.isNullOrBlank()
-        val atlasEnabled = state.phoneSettings.atlasEnabled && !atlasDisabled
-        switchPreference(
-            modifier = Modifier
-                .padding(horizontal = 8.dp)
-                .background(color = surface, shape = atlasShape)
-                .clip(atlasShape),
-            value = atlasEnabled,
-            enabled = { !atlasDisabled },
-            key = "phone_flags_atlas",
-            title = { _ ->
-                Text(
-                    text = stringResource(R.string.screen_experiments_phone_feature_atlas),
-                    style = MaterialTheme.typography.bodyLarge
-                )
-            },
-            summary = { _ ->
-                if (!atlasDisabled) {
-                    val title = stringResource(R.string.screen_experiments_phone_feature_atlas)
-                    Text(text = stringResource(R.string.screen_experiments_phone_subtitle, title))
-                } else {
-                    Text(text = stringResource(R.string.screen_experiments_phone_feature_disabled))
-                }
-            },
-            onValueChange = {
-                interactions.onPhoneAtlasEnabledChanged(it)
-            }
-        )
-
-        item {
-            Spacer(Modifier.height(2.dp))
-        }
-
-        val beeslyShape = Shape(phoneFlagsCount, 3)
-        val beeslyDisabled = state.phoneSettings.beesly.isNullOrBlank()
-        val beeslyEnabled = state.phoneSettings.beeslyEnabled && !beeslyDisabled
-        switchPreference(
-            modifier = Modifier
-                .padding(horizontal = 8.dp)
-                .background(color = surface, shape = beeslyShape)
-                .clip(beeslyShape),
-            value = beeslyEnabled,
-            enabled = { !beeslyDisabled },
-            key = "phone_flags_beesly",
-            title = { _ ->
-                Text(
-                    text = stringResource(R.string.screen_experiments_phone_feature_beesly),
-                    style = MaterialTheme.typography.bodyLarge
-                )
-            },
-            summary = { _ ->
-                if (!beeslyDisabled) {
-                    val title = stringResource(R.string.screen_experiments_phone_feature_beesly)
-                    Text(text = stringResource(R.string.screen_experiments_phone_subtitle, title))
-                } else {
-                    Text(text = stringResource(R.string.screen_experiments_phone_feature_disabled))
-                }
-            },
-            onValueChange = {
-                interactions.onPhoneBeeslyEnabledChanged(it)
-            }
-        )
-
-        item {
-            Spacer(Modifier.height(2.dp))
-        }
-
-        if (beeslyEnabled) {
-            val beeslyRegionShape = Shape(phoneFlagsCount, 3)
-            listPreference(
+            val callRecordingShape = Shape(phoneFlagsCount, 10)
+            switchPreference(
                 modifier = Modifier
                     .padding(horizontal = 8.dp)
-                    .background(color = surface, shape = beeslyRegionShape)
-                    .clip(beeslyRegionShape),
-                value = state.phoneSettings.beeslyRegion,
-                values = BeeslyRegion.entries,
-                key = "phone_flags_beesly_region",
+                    .background(color = surface, shape = callRecordingShape)
+                    .clip(callRecordingShape),
+                value = state.phoneSettings.callRecordingEnabled,
+                key = "phone_flags_call_recording",
                 title = { _ ->
                     Text(
-                        text = stringResource(R.string.screen_experiments_phone_feature_beesly_region),
+                        text = stringResource(R.string.screen_experiments_phone_feature_call_recording),
                         style = MaterialTheme.typography.bodyLarge
                     )
                 },
-                valueToText = {
-                    AnnotatedString(resources.getString(it.label))
-                },
-                summary = {
-                    Text(text = stringResource(it.label))
+                summary = { _ ->
+                    val title =
+                        stringResource(R.string.screen_experiments_phone_feature_call_recording)
+                    Text(text = stringResource(R.string.screen_experiments_phone_subtitle, title))
                 },
                 onValueChange = {
-                    interactions.onPhoneBeeslyRegionChanged(it)
+                    interactions.onPhoneCallRecordingEnabledChanged(it)
                 }
             )
-
-            item {
-                Spacer(Modifier.height(2.dp))
-            }
         }
-
-        val nautilusShape = Shape(phoneFlagsCount, 4)
-        switchPreference(
-            modifier = Modifier
-                .padding(horizontal = 8.dp)
-                .background(color = surface, shape = nautilusShape)
-                .clip(nautilusShape),
-            value = state.phoneSettings.nautilusEnabled,
-            key = "phone_flags_nautilus",
-            title = { _ ->
-                Text(
-                    text = stringResource(R.string.screen_experiments_phone_feature_nautilus),
-                    style = MaterialTheme.typography.bodyLarge
-                )
-            },
-            summary = { _ ->
-                val title = stringResource(R.string.screen_experiments_phone_feature_nautilus)
-                Text(text = stringResource(R.string.screen_experiments_phone_subtitle, title))
-            },
-            onValueChange = {
-                interactions.onPhoneNautilusEnabledChanged(it)
-            }
-        )
-
-        item {
-            Spacer(Modifier.height(2.dp))
-        }
-
-        val sonicShape = Shape(phoneFlagsCount, 5)
-        switchPreference(
-            modifier = Modifier
-                .padding(horizontal = 8.dp)
-                .background(color = surface, shape = sonicShape)
-                .clip(sonicShape),
-            value = state.phoneSettings.sonicEnabled,
-            key = "phone_flags_sonic",
-            title = { _ ->
-                Text(
-                    text = stringResource(R.string.screen_experiments_phone_feature_sonic),
-                    style = MaterialTheme.typography.bodyLarge
-                )
-            },
-            summary = { _ ->
-                val title = stringResource(R.string.screen_experiments_phone_feature_sonic)
-                Text(text = stringResource(R.string.screen_experiments_phone_subtitle, title))
-            },
-            onValueChange = {
-                interactions.onPhoneSonicEnabledChanged(it)
-            }
-        )
-
-        item {
-            Spacer(Modifier.height(2.dp))
-        }
-
-        val xatuShape = Shape(phoneFlagsCount, 5)
-        val xatuDisabled = state.phoneSettings.xatuModels.isNullOrBlank()
-        val xatuEnabled = state.phoneSettings.xatuEnabled && !xatuDisabled
-        switchPreference(
-            modifier = Modifier
-                .padding(horizontal = 8.dp)
-                .background(color = surface, shape = xatuShape)
-                .clip(xatuShape),
-            value = xatuEnabled,
-            enabled = { !xatuDisabled },
-            key = "phone_flags_xatu",
-            title = { _ ->
-                Text(
-                    text = stringResource(R.string.screen_experiments_phone_feature_xatu),
-                    style = MaterialTheme.typography.bodyLarge
-                )
-            },
-            summary = { _ ->
-                if (!xatuDisabled) {
-                    val title = stringResource(R.string.screen_experiments_phone_feature_xatu)
-                    Text(text = stringResource(R.string.screen_experiments_phone_subtitle, title))
-                } else {
-                    Text(text = stringResource(R.string.screen_experiments_phone_feature_disabled))
-                }
-            },
-            onValueChange = {
-                interactions.onPhoneXatuEnabledChanged(it)
-            }
-        )
-
-        item {
-            Spacer(Modifier.height(2.dp))
-        }
-
-        val callerTagsShape = Shape(phoneFlagsCount, 6)
-        switchPreference(
-            modifier = Modifier
-                .padding(horizontal = 8.dp)
-                .background(color = surface, shape = callerTagsShape)
-                .clip(callerTagsShape),
-            value = state.phoneSettings.callerTagsEnabled,
-            key = "phone_flags_caller_tags",
-            title = { _ ->
-                Text(
-                    text = stringResource(R.string.screen_experiments_phone_feature_caller_tags),
-                    style = MaterialTheme.typography.bodyLarge
-                )
-            },
-            summary = { _ ->
-                val title = stringResource(R.string.screen_experiments_phone_feature_caller_tags)
-                Text(text = stringResource(R.string.screen_experiments_phone_subtitle, title))
-            },
-            onValueChange = {
-                interactions.onPhoneCallerTagsEnabledChanged(it)
-            }
-        )
-
-        item {
-            Spacer(Modifier.height(2.dp))
-        }
-
-        val fermatShape = Shape(phoneFlagsCount, 7)
-        switchPreference(
-            modifier = Modifier
-                .padding(horizontal = 8.dp)
-                .background(color = surface, shape = fermatShape)
-                .clip(fermatShape),
-            value = state.phoneSettings.fermatEnabled,
-            key = "phone_flags_fermat",
-            title = { _ ->
-                Text(
-                    text = stringResource(R.string.screen_experiments_phone_feature_fermat),
-                    style = MaterialTheme.typography.bodyLarge
-                )
-            },
-            summary = { _ ->
-                val title = stringResource(R.string.screen_experiments_phone_feature_fermat)
-                Text(text = stringResource(R.string.screen_experiments_phone_subtitle, title))
-            },
-            onValueChange = {
-                interactions.onPhoneFermatEnabledChanged(it)
-            }
-        )
-
-        item {
-            Spacer(Modifier.height(2.dp))
-        }
-
-        val expressiveShape = Shape(phoneFlagsCount, 8)
-        switchPreference(
-            modifier = Modifier
-                .padding(horizontal = 8.dp)
-                .background(color = surface, shape = expressiveShape)
-                .clip(expressiveShape),
-            value = state.phoneSettings.expressoEnabled,
-            key = "phone_flags_expresso",
-            title = { _ ->
-                Text(
-                    text = stringResource(R.string.screen_experiments_phone_feature_expresso),
-                    style = MaterialTheme.typography.bodyLarge
-                )
-            },
-            summary = { _ ->
-                val title = stringResource(R.string.screen_experiments_phone_feature_expresso)
-                Text(text = stringResource(R.string.screen_experiments_phone_subtitle, title))
-            },
-            onValueChange = {
-                interactions.onPhoneExpressoEnabledChanged(it)
-            }
-        )
-
-        item {
-            Spacer(Modifier.height(2.dp))
-        }
-
-        val patrickShape = Shape(phoneFlagsCount, 9)
-        listPreference(
-            modifier = Modifier
-                .padding(horizontal = 8.dp)
-                .background(color = surface, shape = patrickShape)
-                .clip(patrickShape),
-            value = state.phoneSettings.patrickPhase,
-            values = PatrickPhase.entries,
-            key = "phone_flags_patrick",
-            title = { _ ->
-                Text(
-                    text = stringResource(R.string.screen_experiments_phone_feature_patrick),
-                    style = MaterialTheme.typography.bodyLarge
-                )
-            },
-            valueToText = {
-                AnnotatedString(resources.getString(it.label))
-            },
-            summary = {
-                Text(text = stringResource(it.label))
-            },
-            onValueChange = {
-                interactions.onPhonePatrickChanged(it)
-            }
-        )
-
-        item {
-            Spacer(Modifier.height(2.dp))
-        }
-
-        val callRecordingShape = Shape(phoneFlagsCount, 10)
-        switchPreference(
-            modifier = Modifier
-                .padding(horizontal = 8.dp)
-                .background(color = surface, shape = callRecordingShape)
-                .clip(callRecordingShape),
-            value = state.phoneSettings.callRecordingEnabled,
-            key = "phone_flags_call_recording",
-            title = { _ ->
-                Text(
-                    text = stringResource(R.string.screen_experiments_phone_feature_call_recording),
-                    style = MaterialTheme.typography.bodyLarge
-                )
-            },
-            summary = { _ ->
-                val title = stringResource(R.string.screen_experiments_phone_feature_call_recording)
-                Text(text = stringResource(R.string.screen_experiments_phone_subtitle, title))
-            },
-            onValueChange = {
-                interactions.onPhoneCallRecordingEnabledChanged(it)
-            }
-        )
 
         if(state.magicCueAvailable) {
             preferenceCategory(
@@ -667,6 +727,117 @@ private fun LoadedContent(state: State.Loaded, interactions: Interactions) {
             )
         }
 
+        if (state.nowPlayingAvailable) {
+            preferenceCategory(
+                key = "category_as",
+                title = {
+                    Text(stringResource(R.string.screen_experiments_category_as))
+                }
+            )
+
+            val nowPlayingShape = Shape(1, 0)
+            switchPreference(
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .background(color = surface, shape = nowPlayingShape)
+                    .clip(nowPlayingShape),
+                value = state.propertiesState.asNowPlayingNotificationEnabled,
+                key = "as_now_playing",
+                title = {
+                    Text(
+                        text = stringResource(R.string.screen_experiments_as_show_notification_title),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                },
+                summary = {
+                    Text(text = textResource(R.string.screen_experiments_as_show_notification_content))
+                },
+                onValueChange = interactions.onAsNowPlayingChanged
+            )
+        }
+
+        preferenceCategory(
+            key = "category_advanced",
+            title = {
+                Text(stringResource(R.string.screen_experiments_category_advanced))
+            }
+        )
+
+        val clearMddShape = Shape(3, 0)
+        preference(
+            modifier = Modifier
+                .padding(horizontal = 8.dp)
+                .background(color = surface, shape = clearMddShape)
+                .clip(clearMddShape),
+            key = "advanced_clear_mdd",
+            title = {
+                Text(
+                    text = stringResource(R.string.screen_experiments_clear_mdd_title),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            },
+            summary = {
+                Text(text = textResource(R.string.screen_experiments_clear_mdd_content))
+            },
+            onClick = interactions.onClearMddClicked
+        )
+
+        item {
+            Spacer(Modifier.height(2.dp))
+        }
+
+        val clearOverridesShape = Shape(3, 1)
+        preference(
+            modifier = Modifier
+                .padding(horizontal = 8.dp)
+                .background(color = surface, shape = clearOverridesShape)
+                .clip(clearOverridesShape),
+            key = "advanced_clear_overrides",
+            title = {
+                Text(
+                    text = stringResource(R.string.screen_experiments_clear_overrides_title),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            },
+            summary = {
+                Text(text = textResource(R.string.screen_experiments_clear_overrides_content))
+            },
+            onClick = interactions.onClearOverridesClicked
+        )
+
+        item {
+            Spacer(Modifier.height(2.dp))
+        }
+
+        val clientGroupOverridesShape = Shape(3, 2)
+        listPreference(
+            modifier = Modifier
+                .padding(horizontal = 8.dp)
+                .background(color = surface, shape = clientGroupOverridesShape)
+                .clip(clientGroupOverridesShape),
+            key = "advanced_client_group_overrides",
+            value = state.propertiesState.clientGroupOverride,
+            values = ClientGroupOverride.entries,
+            title = { _ ->
+                Text(
+                    text = stringResource(R.string.screen_experiments_client_group_override_title),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            },
+            valueToText = {
+                AnnotatedString(resources.getString(it.title))
+            },
+            summary = {
+                Text(text = stringResource(
+                    R.string.screen_experiments_client_group_override_content,
+                    stringResource(state.propertiesState.clientGroupOverride.title)
+                ))
+            },
+            onValueChange = {
+                interactions.onClientGroupOverrideChanged(it)
+            }
+        )
+
         item {
             Spacer(Modifier.navigationBarsPadding()
                 .padding(bottom = 16.dp))
@@ -680,6 +851,8 @@ private fun ContentPreviewLight() {
     PcsTheme {
         val state = State.Loaded(
             magicCueAvailable = true,
+            nowPlayingAvailable = true,
+            phoneAvailable = true,
             phoneSettings = PhoneSettings(
                 sharpieEnabled = false,
                 dobbyEnabled = false,

--- a/app/src/main/java/com/kieronquinn/app/pcs/ui/screens/experiments/ExperimentsViewModel.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/ui/screens/experiments/ExperimentsViewModel.kt
@@ -1,18 +1,25 @@
 package com.kieronquinn.app.pcs.ui.screens.experiments
 
+import android.content.ComponentName
 import android.content.Context
 import android.content.pm.PackageManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_AIC
+import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_AS
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_PHONE
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_PSI
+import com.kieronquinn.app.pcs.model.ClientGroupOverride
 import com.kieronquinn.app.pcs.model.phone.PhoneSettings
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository
+import com.kieronquinn.app.pcs.repositories.PhenotypeRepository
 import com.kieronquinn.app.pcs.repositories.PropertiesRepository
 import com.kieronquinn.app.pcs.repositories.SettingsRepository
 import com.kieronquinn.app.pcs.repositories.SettingsRepository.BeeslyRegion
 import com.kieronquinn.app.pcs.repositories.SettingsRepository.DobbyRegion
 import com.kieronquinn.app.pcs.repositories.SettingsRepository.PatrickPhase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -23,6 +30,7 @@ import kotlinx.coroutines.launch
 abstract class ExperimentsViewModel: ViewModel() {
 
     abstract val state: StateFlow<State>
+    abstract val events: Flow<Event>
 
     abstract fun onPhoneSharpieEnabledChanged(enabled: Boolean)
     abstract fun onPhoneDobbyEnabledChanged(enabled: Boolean)
@@ -44,13 +52,25 @@ abstract class ExperimentsViewModel: ViewModel() {
     abstract fun onPsiForceAccountTypeChanged(enabled: Boolean)
     abstract fun onPsiForceAdminAllowanceChanged(enabled: Boolean)
 
+    abstract fun onAsNowPlayingChanged(enabled: Boolean)
+
+    abstract fun onClearMddClicked()
+    abstract fun onClearOverridesClicked()
+    abstract fun onClientGroupOverrideChanged(override: ClientGroupOverride)
+
     sealed class State {
         data object Loading: State()
         data class Loaded(
             val magicCueAvailable: Boolean,
+            val nowPlayingAvailable: Boolean,
+            val phoneAvailable: Boolean,
             val phoneSettings: PhoneSettings,
             val propertiesState: PropertiesRepository.State
         ): State()
+    }
+
+    enum class Event {
+        MANIFESTS_PURGED, MANIFEST_OVERRIDES_CLEARED
     }
 
 }
@@ -58,6 +78,7 @@ abstract class ExperimentsViewModel: ViewModel() {
 class ExperimentsViewModelImpl(
     private val propertiesRepository: PropertiesRepository,
     private val deviceConfigPropertiesRepository: DeviceConfigPropertiesRepository,
+    private val phenotypeRepository: PhenotypeRepository,
     settingsRepository: SettingsRepository,
     context: Context
 ): ExperimentsViewModel() {
@@ -90,6 +111,31 @@ class ExperimentsViewModelImpl(
             null
         }
         emit(versionName != null && !versionName.contains("stub"))
+    }
+
+    private val isPhoneAvailable = flow {
+        val versionName = try {
+            context.packageManager.getPackageInfo(PACKAGE_NAME_PHONE, 0)
+                ?.versionName
+        } catch (e: PackageManager.NameNotFoundException) {
+            null
+        }
+        emit(versionName != null && versionName.contains("pixel"))
+    }
+
+    private val isNowPlayingAvailable = flow {
+        try {
+            context.packageManager.getServiceInfo(
+                ComponentName(
+                    PACKAGE_NAME_AS,
+                    "com.google.android.apps.miphone.aiai.nowplaying.api.NowPlayingService"
+                ),
+                0
+            )
+            emit(true)
+        } catch (e: PackageManager.NameNotFoundException) {
+            emit(false)
+        }
     }
 
     private val phoneBooleanSettings = combine(
@@ -156,15 +202,21 @@ class ExperimentsViewModelImpl(
 
     override val state = combine(
         isMagicCueAvailable,
+        isNowPlayingAvailable,
+        isPhoneAvailable,
         propertiesRepository.state,
         phoneSettings
-    ) { magicCueAvailable, propertiesState, phoneSettings ->
+    ) { magicCueAvailable, nowPlayingAvailable, isPhoneAvailable, propertiesState, phoneSettings ->
         State.Loaded(
             magicCueAvailable = magicCueAvailable,
+            nowPlayingAvailable = nowPlayingAvailable,
+            phoneAvailable = isPhoneAvailable,
             phoneSettings = phoneSettings,
             propertiesState = propertiesState
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, State.Loading)
+
+    override val events = MutableSharedFlow<Event>()
 
     override fun onPhoneSharpieEnabledChanged(enabled: Boolean) {
         viewModelScope.launch {
@@ -285,6 +337,34 @@ class ExperimentsViewModelImpl(
     override fun onPsiForceAdminAllowanceChanged(enabled: Boolean) {
         viewModelScope.launch {
             propertiesRepository.setPsiForceAdminAllowance(enabled)
+        }
+    }
+
+    override fun onAsNowPlayingChanged(enabled: Boolean) {
+        viewModelScope.launch {
+            propertiesRepository.setAsNowPlayingNotificationEnabled(enabled)
+        }
+    }
+
+    override fun onClearMddClicked() {
+        viewModelScope.launch {
+            deviceConfigPropertiesRepository.clearMdd(PACKAGE_NAME_AIC)
+            deviceConfigPropertiesRepository.clearMdd(PACKAGE_NAME_PSI)
+            deviceConfigPropertiesRepository.clearMdd(PACKAGE_NAME_PHONE)
+            events.emit(Event.MANIFESTS_PURGED)
+        }
+    }
+
+    override fun onClearOverridesClicked() {
+        viewModelScope.launch {
+            phenotypeRepository.resetVersions()
+            events.emit(Event.MANIFEST_OVERRIDES_CLEARED)
+        }
+    }
+
+    override fun onClientGroupOverrideChanged(override: ClientGroupOverride) {
+        viewModelScope.launch {
+            propertiesRepository.setClientGroupOverride(override)
         }
     }
 

--- a/app/src/main/java/com/kieronquinn/app/pcs/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/ui/screens/settings/SettingsViewModel.kt
@@ -63,7 +63,7 @@ class SettingsViewModelImpl(
     private val propertiesRepository: PropertiesRepository,
     private val syncRepository: SyncRepository,
     private val settingsRepository: SettingsRepository,
-    phenotypeRepository: PhenotypeRepository,
+    private val phenotypeRepository: PhenotypeRepository,
     manifestRepository: ManifestRepository,
     updateRepository: UpdateRepository,
     context: Context
@@ -172,8 +172,15 @@ class SettingsViewModelImpl(
         RefreshWorker.setEnabled(workManager, enabled)
     }
 
+    private fun setupLabelResetListener() = viewModelScope.launch {
+        phenotypeRepository.onVersionsReset.collect {
+            refreshBus.emit(System.currentTimeMillis())
+        }
+    }
+
     init {
         syncWorker()
+        setupLabelResetListener()
         manifestRepository.refresh()
     }
 

--- a/app/src/main/java/com/kieronquinn/app/pcs/utils/extensions/Extensions+SystemProperties.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/utils/extensions/Extensions+SystemProperties.kt
@@ -15,3 +15,17 @@ fun SystemProperties_getBoolean(key: String, defaultValue: Boolean): Boolean {
     }
     return defaultValue
 }
+
+@SuppressLint("PrivateApi")
+fun SystemProperties_get(key: String): String? {
+    runCatching {
+        val systemProperties = Class.forName("android.os.SystemProperties")
+        systemProperties.getMethod("get", String::class.java)
+            .invoke(null, key) as? String
+    }.onSuccess {
+        return it
+    }.onFailure {
+        return null
+    }
+    return null
+}

--- a/app/src/main/java/com/kieronquinn/app/pcs/xposed/AsHooks.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/xposed/AsHooks.kt
@@ -1,0 +1,57 @@
+package com.kieronquinn.app.pcs.xposed
+
+import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.AS_SHOW_NOW_PLAYING_NOTIFICATION
+import com.kieronquinn.app.pcs.utils.extensions.SystemProperties_getBoolean
+import de.robv.android.xposed.XC_MethodHook
+import de.robv.android.xposed.XposedHelpers
+import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam
+import java.lang.reflect.Modifier
+
+/**
+ *  Hooks ASI, intercepting the DeviceConfig call to check if New Now Playing is enabled, and
+ *  selectively returns false for notifications, which allows them to show again.
+ */
+object AsHooks: XposedHooks {
+
+    private const val NAMESPACE_NOW_PLAYING = "systemui"
+    private const val FLAG_NEW_NOW_PLAYING =
+        "com.google.android.systemui.now_playing_lockscreen_extended_interaction"
+
+    override val tag = "AsHooks"
+
+    override fun hook(loadPackageParam: LoadPackageParam) {
+        XposedHelpers.findAndHookMethod(
+            "android.provider.DeviceConfig",
+            loadPackageParam.classLoader,
+            "getBoolean",
+            String::class.java,
+            String::class.java,
+            Boolean::class.java,
+            object: XC_MethodHook() {
+                override fun beforeHookedMethod(param: MethodHookParam) {
+                    if (param.args[0] == NAMESPACE_NOW_PLAYING &&
+                        param.args[1] == FLAG_NEW_NOW_PLAYING &&
+                        SystemProperties_getBoolean(AS_SHOW_NOW_PLAYING_NOTIFICATION, false) &&
+                        getCallingInformation(1)
+                            ?.isNotificationClass(loadPackageParam.classLoader) == true) {
+                        param.result = false
+                    }
+                }
+            }
+        )
+    }
+
+    private fun Triple<String, String, List<String>>.isNotificationClass(
+        classLoader: ClassLoader
+    ): Boolean {
+        val clazz = XposedHelpers.findClass(first, classLoader)
+        return clazz.methods.any {
+            it.name == second && Modifier.isFinal(it.modifiers)
+                    && it.parameterCount == 5
+                    && it.parameterTypes[0] == String::class.java
+                    && it.parameterTypes[2].simpleName == "Duration"
+                    && it.parameterTypes[4] == Boolean::class.java
+        }
+    }
+
+}

--- a/app/src/main/java/com/kieronquinn/app/pcs/xposed/PhoneHooks.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/xposed/PhoneHooks.kt
@@ -255,6 +255,9 @@ object PhoneHooks: GrpcHooks() {
             PhoneFlag.BEESLY_ACTIONS_ENABLED -> if (settings.beeslyEnabled) {
                 true
             } else null
+            PhoneFlag.BEESLY_GREETING_ENABLED -> if (settings.beeslyEnabled) {
+                true
+            } else null
             PhoneFlag.NAUTILUS_ENABLED -> if (settings.nautilusEnabled) {
                 true
             } else null
@@ -290,17 +293,20 @@ object PhoneHooks: GrpcHooks() {
             PhoneFlag.PATRICK_PHASE_TWO_ENABLE_REPOSITORY -> if (settings.patrickPhase >= PatrickPhase.PHASE_TWO) {
                 true
             } else null
-            PhoneFlag.CALL_RECORDING_OVERRIDE_ENABLED -> if (settings.callRecordingEnabled && settings.fermatEnabled) {
+            PhoneFlag.CALL_RECORDING_OVERRIDE_ENABLED -> if (settings.callRecordingEnabled) {
                 true
             } else null
-            PhoneFlag.CALL_RECORDING_ENABLED -> if (settings.callRecordingEnabled && settings.fermatEnabled) {
+            PhoneFlag.CALL_RECORDING_ENABLED -> if (settings.callRecordingEnabled) {
                 true
             } else null
-            PhoneFlag.CALL_RECORDING_FORCE_OVERRIDE_ENABLED -> if (settings.callRecordingEnabled && settings.fermatEnabled) {
+            PhoneFlag.CALL_RECORDING_FORCE_OVERRIDE_ENABLED -> if (settings.callRecordingEnabled) {
                 true
             } else null
-            PhoneFlag.CALL_RECORDING_CROSBY_ENABLED -> if (settings.callRecordingEnabled && settings.fermatEnabled) {
+            PhoneFlag.CALL_RECORDING_CROSBY_ENABLED -> if (settings.callRecordingEnabled) {
                 true
+            } else null
+            PhoneFlag.CALL_RECORDING_FERMAT_DISABLE -> if (settings.callRecordingEnabled) {
+                false
             } else null
         }
     }

--- a/app/src/main/java/com/kieronquinn/app/pcs/xposed/Xposed.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/xposed/Xposed.kt
@@ -1,6 +1,7 @@
 package com.kieronquinn.app.pcs.xposed
 
 import com.kieronquinn.app.pcs.BuildConfig
+import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_AS
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_PCS
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_PHONE
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_PSI
@@ -26,6 +27,9 @@ class Xposed: IXposedHookLoadPackage {
             }
             PACKAGE_NAME_TTS -> {
                 TtsHooks.hook(lpparam)
+            }
+            PACKAGE_NAME_AS -> {
+                AsHooks.hook(lpparam)
             }
         }
         if (lpparam.packageName != BuildConfig.APPLICATION_ID) {

--- a/app/src/main/java/com/kieronquinn/app/pcs/xposed/XposedHooks.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/xposed/XposedHooks.kt
@@ -15,4 +15,15 @@ interface XposedHooks {
         XposedBridge.log("$tag: $message")
     }
 
+    fun getCallingInformation(offset: Int = 0): Triple<String, String, List<String>>? {
+        val stackTrace = Thread.currentThread().stackTrace
+        val classList = stackTrace.map { it.className }
+        // Because Google strips the code filenames, we can abuse this to find the immediate caller
+        val callerIndex = (stackTrace.indexOfFirst {
+            it.fileName == "PG"
+        }.takeIf { it >= 0 } ?: return null) + offset
+        val caller = stackTrace.getOrNull(callerIndex) ?: return null
+        return Triple(caller.className, caller.methodName, classList)
+    }
+
 }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -2,6 +2,7 @@
 <resources>
     <string-array name="xposed_scope">
         <item>com.google.android.as.oss</item>
+        <item>com.google.android.as</item>
         <item>com.google.android.dialer</item>
         <item>com.google.android.apps.pixel.psi</item>
         <item>com.google.android.tts</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,6 +112,27 @@
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
 
+    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
+    <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
+
+    <string name="screen_experiments_category_advanced">Advanced</string>
+    <string name="screen_experiments_clear_mdd_title">Purge Cached Manifests</string>
+    <string name="screen_experiments_clear_mdd_content">Clear manifests cached by apps. This will force them to re-sync from the repository, even if up to date, and may use data to do so.</string>
+    <string name="screen_experiments_clear_mdd_toast">Manifests purged</string>
+    <string name="screen_experiments_clear_overrides_title">Clear Manifest Overrides</string>
+    <string name="screen_experiments_clear_overrides_content">Reset manifest versions to system-provided values for this device. Use this if you need to uninstall Public Compute Services or a manifest version is stuck.</string>
+    <string name="screen_experiments_clear_overrides_toast">Manifest overrides cleared</string>
+    <string name="screen_experiments_client_group_override_title">Override Preferred Manifest Channel</string>
+    <string name="screen_experiments_client_group_override_content">Force a specific preferred manifest channel, regardless of which AICore version is installed: %1s\n\nKeep this disabled unless you know what you\'re doing.</string>
+
+    <string name="client_group_override_disabled">Do not override</string>
+    <string name="client_group_override_all">All</string>
+    <string name="client_group_override_alpha">Alpha</string>
+    <string name="client_group_override_beta">Beta</string>
+    <string name="client_group_override_third_party_eap">Third Party EAP</string>
+    <string name="client_group_override_third_party_experiental">Third Party Experimental</string>
+
     <string name="screen_contributors_astrea_title">Private Compute Services</string>
     <string name="screen_contributors_astrea_content">Contains code from Private Compute Services, under the Apache-2.0 licence</string>
     <string name="screen_contributors_icons_title">Additional Icons</string>


### PR DESCRIPTION
- Manifest picker now takes into account the requested channel when selecting a manifest, to allow for alpha, beta and third party experimental manifest use
- Added option to override the preferred manifest channel (fixes Magic Cue)
- Added option to purge cached manifests in Magic Cue, AI Core and Phone
- Added option to clear manifest overrides, resetting manifest versions to allow re-applying if they are stuck
- Added option to show the Now Playing notification with new Now Playing enabled, which allows Now Playing history apps to work again
- Fixed Call Recording not appearing on some devices
- Enabled Take a Message greeting when Take a Message is enabled