### PR TITLE
1.0.4

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ private fun getLocalProperties(): Properties? {
 
 val currentLocalProperties = getLocalProperties()
 
-val tagName = "1.0.3"
-val tagCode = 103
+val tagName = "1.0.4"
+val tagCode = 104
 
 android {
     namespace = "com.kieronquinn.app.pcs"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,6 +76,7 @@
 
     <queries>
         <package android:name="com.google.android.apps.pixel.psi"/>
+        <package android:name="com.google.android.apps.pixel.agent"/>
         <package android:name="com.google.android.dialer"/>
         <package android:name="com.google.android.as"/>
         <package android:name="com.google.android.aicore"/>

--- a/app/src/main/java/com/kieronquinn/app/pcs/PcsApplication.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/PcsApplication.kt
@@ -50,6 +50,7 @@ class PcsApplication: Application() {
         const val PACKAGE_NAME_TTS = "com.google.android.tts"
         const val PACKAGE_NAME_AS = "com.google.android.as"
         const val PACKAGE_NAME_AIC = "com.google.android.aicore"
+        const val PACKAGE_NAME_AGENT = "com.google.android.apps.pixel.agent"
     }
 
     override fun onCreate() {

--- a/app/src/main/java/com/kieronquinn/app/pcs/grpc/ProtectedDownloadGrpcService.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/grpc/ProtectedDownloadGrpcService.kt
@@ -24,6 +24,7 @@ import com.kieronquinn.app.pcs.utils.extensions.buildId
 import com.kieronquinn.app.pcs.utils.extensions.client
 import com.kieronquinn.app.pcs.utils.extensions.clientGroup
 import com.kieronquinn.app.pcs.utils.extensions.country
+import com.kieronquinn.app.pcs.utils.extensions.device
 import com.kieronquinn.app.pcs.utils.extensions.deviceModel
 import com.kieronquinn.app.pcs.utils.extensions.deviceTier
 import com.kieronquinn.app.pcs.utils.extensions.modelType
@@ -61,6 +62,7 @@ class ProtectedDownloadGrpcService(
             RequestType.AICORE -> getManifestConfigAiCore(request, responseObserver)
             RequestType.PHONE -> getManifestConfigPhone(request, responseObserver)
             RequestType.TTS -> getManifestConfigTts(request, responseObserver)
+            RequestType.AGENT -> getManifestConfigAgent(request, responseObserver)
             null -> {
                 Log.e("AstreaServiceError", "Unknown request type")
                 Log.e("AstreaServiceError", request.toString())
@@ -144,6 +146,30 @@ class ProtectedDownloadGrpcService(
         }
     }
 
+    private fun getManifestConfigAgent(
+        request: GetManifestConfigRequest,
+        responseObserver: StreamObserver<GetManifestConfigResponse>
+    ) {
+        if (SystemProperties_getBoolean(DEBUG_PROPERTY_NAME, false)) {
+            request.logAgent()
+        }
+        scope.launch(Dispatchers.IO) {
+            val url = ConfigProvider.getRepositoryUrl(context) ?: run {
+                Log.e("AstreaServiceError", "No URL set, unable to download manifest")
+                responseObserver.onError(Throwable())
+                return@launch
+            }
+            val manifest = manifestRepository.getAgentManifest(
+                url, request.constraints.clientId, request.constraints.device
+            )
+            responseObserver.sendBackManifest(
+                manifest,
+                request.constraints.clientId,
+                request.cryptoKeys
+            )
+        }
+    }
+
     private fun StreamObserver<GetManifestConfigResponse>.sendBackManifest(
         manifest: ByteArray?,
         clientId: String,
@@ -174,6 +200,9 @@ class ProtectedDownloadGrpcService(
     private fun GetManifestConfigRequest.getType(): RequestType? {
         val constraintLabels = constraints.labelList.map { it.attribute }
         return when {
+            constraints.clientId.startsWith("com.google.android.apps.pixel.agent") -> {
+                RequestType.AGENT
+            }
             constraintLabels.contains("device_tier") -> RequestType.AICORE
             constraintLabels.contains("country") -> RequestType.PHONE
             constraintLabels.contains("device_model") -> RequestType.TTS
@@ -217,8 +246,19 @@ class ProtectedDownloadGrpcService(
         Log.d(TAG, "==== End Manifest Config Request ====")
     }
 
+    @Synchronized
+    private fun GetManifestConfigRequest.logAgent() {
+        Log.d(TAG, "==== Get Manifest Config Request (Agent) ====")
+        Log.d(TAG, "Client ID: ${constraints.clientId}")
+        Log.d(TAG, "Client Version: ${constraints.clientVersion.version}")
+        Log.d(TAG, "Device: ${constraints.device}")
+        Log.d(TAG, "Build ID: ${constraints.buildId}")
+        Log.d(TAG, "Compress: ${manifestTransform.compressManifest}")
+        Log.d(TAG, "==== End Manifest Config Request ====")
+    }
+
     private enum class RequestType {
-        AICORE, PHONE, TTS
+        AICORE, PHONE, TTS, AGENT
     }
 
 }

--- a/app/src/main/java/com/kieronquinn/app/pcs/providers/ConfigProvider.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/providers/ConfigProvider.kt
@@ -9,6 +9,7 @@ import android.os.Bundle
 import androidx.core.net.toUri
 import androidx.core.os.bundleOf
 import com.kieronquinn.app.pcs.BuildConfig
+import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_AGENT
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_PHONE
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_TTS
 import com.kieronquinn.app.pcs.model.PcsClient.BuildId.Namespace.DEVICE_PERSONALIZATION_SERVICES
@@ -32,6 +33,7 @@ class ConfigProvider: ContentProvider() {
         private val PACKAGE_ALLOWLIST = setOf(
             PACKAGE_NAME_PHONE,
             PACKAGE_NAME_TTS,
+            PACKAGE_NAME_AGENT,
             BuildConfig.APPLICATION_ID
         )
 

--- a/app/src/main/java/com/kieronquinn/app/pcs/repositories/AstreaRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/repositories/AstreaRepository.kt
@@ -15,9 +15,10 @@ interface AstreaRepository {
 
     companion object {
         const val HOST = "127.0.0.1"
-        const val PORT_PCS = 7270 //PCS0
-        const val PORT_PHONE = 7271 //PCS1
-        const val PORT_TTS = 7272
+        const val PORT_PCS = 7270 // PCS0
+        const val PORT_PHONE = 7271 // PCS1
+        const val PORT_TTS = 7272 // PCS2
+        const val PORT_AGENT = 7273 // PCS3
     }
 
     fun start()

--- a/app/src/main/java/com/kieronquinn/app/pcs/repositories/DeviceConfigPropertiesRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/repositories/DeviceConfigPropertiesRepository.kt
@@ -25,6 +25,9 @@ interface DeviceConfigPropertiesRepository {
         const val PSI_FORCE_ADMIN_ALLOWANCE_PROPERTY_NAME = "persist.psi.force_admin_allowance"
         const val PSI_CLIENT_GROUP_OVERRIDE_PROPERTY_NAME = "persist.psi.client_group_override"
         const val AS_SHOW_NOW_PLAYING_NOTIFICATION = "persist.as.show_now_playing_notification"
+        const val PHONE_ENABLED = "persist.phone.pcs_enabled"
+        const val TTS_ENABLED = "persist.tts.pcs_enabled"
+        const val AGENT_ENABLED = "persist.agent.pcs_enabled"
     }
 
     /**

--- a/app/src/main/java/com/kieronquinn/app/pcs/repositories/ManifestRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/repositories/ManifestRepository.kt
@@ -45,6 +45,7 @@ interface ManifestRepository {
     ): ByteArray?
     suspend fun getPhoneManifest(url: String, clientId: String): ByteArray?
     suspend fun getTtsManifest(url: String, id: String): ByteArray?
+    suspend fun getAgentManifest(url: String, id: String, device: String?): ByteArray?
 
     sealed class ManifestState {
         data object Loading: ManifestState()
@@ -199,6 +200,19 @@ class ManifestRepositoryImpl(
         val mainManifest = getManifests(url) ?: return null
         val manifest = mainManifest.ttsManifestList.firstOrNull {
             id == it.id
+        } ?: return null
+        return getManifest(url, manifest.name, manifest.encryptionKey.toByteArray().toKeysetHandle())
+    }
+
+    override suspend fun getAgentManifest(url: String, id: String, device: String?): ByteArray? {
+        val mainManifest = getManifests(url) ?: return null
+        val requiredId = if (device != null) {
+            "$id:$device"
+        } else {
+            id
+        }
+        val manifest = mainManifest.agentManifestList.firstOrNull {
+            requiredId == it.id
         } ?: return null
         return getManifest(url, manifest.name, manifest.encryptionKey.toByteArray().toKeysetHandle())
     }

--- a/app/src/main/java/com/kieronquinn/app/pcs/repositories/PropertiesRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/repositories/PropertiesRepository.kt
@@ -1,14 +1,20 @@
 package com.kieronquinn.app.pcs.repositories
 
+import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_AGENT
+import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_PHONE
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_PSI
+import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_TTS
 import com.kieronquinn.app.pcs.model.ClientGroupOverride
+import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.AGENT_ENABLED
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.AS_SHOW_NOW_PLAYING_NOTIFICATION
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.DEBUG_PROPERTY_NAME
+import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.PHONE_ENABLED
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.PSI_CLIENT_GROUP_OVERRIDE_PROPERTY_NAME
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.PSI_ENABLE_APPS_PROPERTY_NAME
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.PSI_FORCE_ACCOUNT_PRESENCE_PROPERTY_NAME
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.PSI_FORCE_ACCOUNT_TYPE_PROPERTY_NAME
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.PSI_FORCE_ADMIN_ALLOWANCE_PROPERTY_NAME
+import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.TTS_ENABLED
 import com.kieronquinn.app.pcs.repositories.PropertiesRepository.State
 import com.kieronquinn.app.pcs.utils.extensions.SystemProperties_get
 import com.kieronquinn.app.pcs.utils.extensions.SystemProperties_getBoolean
@@ -32,6 +38,9 @@ interface PropertiesRepository {
     suspend fun setPsiForceAdminAllowance(enabled: Boolean)
     suspend fun setAsNowPlayingNotificationEnabled(enabled: Boolean)
     suspend fun setClientGroupOverride(override: ClientGroupOverride)
+    suspend fun setPhoneEnabled(enabled: Boolean)
+    suspend fun setTtsEnabled(enabled: Boolean)
+    suspend fun setAgentEnabled(enabled: Boolean)
 
     data class State(
         val debug: Boolean = false,
@@ -40,6 +49,9 @@ interface PropertiesRepository {
         val psiForceAccountType: Boolean = false,
         val psiForceAdminAllowance: Boolean = false,
         val asNowPlayingNotificationEnabled: Boolean = false,
+        val phoneEnabled: Boolean = false,
+        val ttsEnabled: Boolean = false,
+        val agentEnabled: Boolean = false,
         val clientGroupOverride: ClientGroupOverride = ClientGroupOverride.DISABLED
     )
 
@@ -93,6 +105,24 @@ class PropertiesRepositoryImpl(
         refreshBus.emit(System.currentTimeMillis())
     }
 
+    override suspend fun setPhoneEnabled(enabled: Boolean) {
+        deviceConfigPropertiesRepository.setProperty(PHONE_ENABLED, enabled.toString())
+        deviceConfigPropertiesRepository.forceStopPackage(PACKAGE_NAME_PHONE)
+        refreshBus.emit(System.currentTimeMillis())
+    }
+
+    override suspend fun setTtsEnabled(enabled: Boolean) {
+        deviceConfigPropertiesRepository.setProperty(TTS_ENABLED, enabled.toString())
+        deviceConfigPropertiesRepository.forceStopPackage(PACKAGE_NAME_TTS)
+        refreshBus.emit(System.currentTimeMillis())
+    }
+
+    override suspend fun setAgentEnabled(enabled: Boolean) {
+        deviceConfigPropertiesRepository.setProperty(AGENT_ENABLED, enabled.toString())
+        deviceConfigPropertiesRepository.forceStopPackage(PACKAGE_NAME_AGENT)
+        refreshBus.emit(System.currentTimeMillis())
+    }
+
     private fun getState(): State {
         return State(
             SystemProperties_getBoolean(DEBUG_PROPERTY_NAME, false),
@@ -101,6 +131,9 @@ class PropertiesRepositoryImpl(
             SystemProperties_getBoolean(PSI_FORCE_ACCOUNT_TYPE_PROPERTY_NAME, false),
             SystemProperties_getBoolean(PSI_FORCE_ADMIN_ALLOWANCE_PROPERTY_NAME, false),
             SystemProperties_getBoolean(AS_SHOW_NOW_PLAYING_NOTIFICATION, false),
+            SystemProperties_getBoolean(PHONE_ENABLED, false),
+            SystemProperties_getBoolean(TTS_ENABLED, false),
+            SystemProperties_getBoolean(AGENT_ENABLED, false),
             ClientGroupOverride.from(SystemProperties_get(PSI_CLIENT_GROUP_OVERRIDE_PROPERTY_NAME))
         )
     }

--- a/app/src/main/java/com/kieronquinn/app/pcs/ui/screens/experiments/ExperimentsScreen.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/ui/screens/experiments/ExperimentsScreen.kt
@@ -68,6 +68,9 @@ private data class Interactions(
     val onPsiForceAdminAllowanceChanged: (Boolean) -> Unit,
     val onAsNowPlayingChanged: (Boolean) -> Unit,
     val onClearMddClicked: () -> Unit,
+    val onPhoneEnabledChanged: (Boolean) -> Unit,
+    val onTtsEnabledChanged: (Boolean) -> Unit,
+    val onAgentEnabledChanged: (Boolean) -> Unit,
     val onClearOverridesClicked: () -> Unit,
     val onClientGroupOverrideChanged: (ClientGroupOverride) -> Unit,
 ) {
@@ -93,6 +96,9 @@ private data class Interactions(
             onPsiForceAdminAllowanceChanged = {},
             onAsNowPlayingChanged = {},
             onClearMddClicked = {},
+            onPhoneEnabledChanged = {},
+            onTtsEnabledChanged = {},
+            onAgentEnabledChanged = {},
             onClearOverridesClicked = {},
             onClientGroupOverrideChanged = {}
         )
@@ -124,6 +130,9 @@ fun ExperimentsScreen() = ProvidePreferenceLocals {
         onPsiForceAdminAllowanceChanged = viewModel::onPsiForceAdminAllowanceChanged,
         onAsNowPlayingChanged = viewModel::onAsNowPlayingChanged,
         onClearMddClicked = viewModel::onClearMddClicked,
+        onPhoneEnabledChanged = viewModel::onPhoneEnabledChanged,
+        onTtsEnabledChanged = viewModel::onTtsEnabledChanged,
+        onAgentEnabledChanged = viewModel::onAgentEnabledChanged,
         onClearOverridesClicked = viewModel::onClearOverridesClicked,
         onClientGroupOverrideChanged = viewModel::onClientGroupOverrideChanged
     )
@@ -786,6 +795,82 @@ private fun LoadedContent(state: State.Loaded, interactions: Interactions) {
             Spacer(Modifier.height(2.dp))
         }
 
+        if (state.phoneAvailable) {
+            val enablePhoneShape = Shape(3, 1)
+            switchPreference(
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .background(color = surface, shape = enablePhoneShape)
+                    .clip(enablePhoneShape),
+                key = "advanced_enable_phone",
+                value = state.propertiesState.phoneEnabled,
+                title = {
+                    Text(
+                        text = stringResource(R.string.screen_experiments_enable_phone_title),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                },
+                summary = {
+                    Text(text = textResource(R.string.screen_experiments_enable_phone_content))
+                },
+                onValueChange = interactions.onPhoneEnabledChanged
+            )
+
+            item {
+                Spacer(Modifier.height(2.dp))
+            }
+
+            val enableTTSShape = Shape(3, 1)
+            switchPreference(
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .background(color = surface, shape = enableTTSShape)
+                    .clip(enableTTSShape),
+                key = "advanced_enable_tts",
+                value = state.propertiesState.ttsEnabled,
+                title = {
+                    Text(
+                        text = stringResource(R.string.screen_experiments_enable_tts_title),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                },
+                summary = {
+                    Text(text = textResource(R.string.screen_experiments_enable_tts_content))
+                },
+                onValueChange = interactions.onTtsEnabledChanged
+            )
+
+            item {
+                Spacer(Modifier.height(2.dp))
+            }
+        }
+
+        if (state.agentAvailable) {
+            val enableAgentShape = Shape(3, 1)
+            switchPreference(
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .background(color = surface, shape = enableAgentShape)
+                    .clip(enableAgentShape),
+                key = "advanced_enable_agent",
+                value = state.propertiesState.agentEnabled,
+                title = {
+                    Text(
+                        text = stringResource(R.string.screen_experiments_enable_agent_title),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                },
+                summary = {
+                    Text(text = textResource(R.string.screen_experiments_enable_agent_content))
+                },
+                onValueChange = interactions.onAgentEnabledChanged
+            )
+
+            item {
+                Spacer(Modifier.height(2.dp))
+            }
+        }
+
         val clearOverridesShape = Shape(3, 1)
         preference(
             modifier = Modifier
@@ -853,6 +938,7 @@ private fun ContentPreviewLight() {
             magicCueAvailable = true,
             nowPlayingAvailable = true,
             phoneAvailable = true,
+            agentAvailable = true,
             phoneSettings = PhoneSettings(
                 sharpieEnabled = false,
                 dobbyEnabled = false,

--- a/app/src/main/java/com/kieronquinn/app/pcs/ui/screens/experiments/ExperimentsViewModel.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/ui/screens/experiments/ExperimentsViewModel.kt
@@ -5,10 +5,12 @@ import android.content.Context
 import android.content.pm.PackageManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_AGENT
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_AIC
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_AS
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_PHONE
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_PSI
+import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_TTS
 import com.kieronquinn.app.pcs.model.ClientGroupOverride
 import com.kieronquinn.app.pcs.model.phone.PhoneSettings
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository
@@ -54,6 +56,9 @@ abstract class ExperimentsViewModel: ViewModel() {
 
     abstract fun onAsNowPlayingChanged(enabled: Boolean)
 
+    abstract fun onPhoneEnabledChanged(enabled: Boolean)
+    abstract fun onTtsEnabledChanged(enabled: Boolean)
+    abstract fun onAgentEnabledChanged(enabled: Boolean)
     abstract fun onClearMddClicked()
     abstract fun onClearOverridesClicked()
     abstract fun onClientGroupOverrideChanged(override: ClientGroupOverride)
@@ -64,6 +69,7 @@ abstract class ExperimentsViewModel: ViewModel() {
             val magicCueAvailable: Boolean,
             val nowPlayingAvailable: Boolean,
             val phoneAvailable: Boolean,
+            val agentAvailable: Boolean,
             val phoneSettings: PhoneSettings,
             val propertiesState: PropertiesRepository.State
         ): State()
@@ -121,6 +127,16 @@ class ExperimentsViewModelImpl(
             null
         }
         emit(versionName != null && versionName.contains("pixel"))
+    }
+
+    private val isAgentAvailable = flow {
+        val versionName = try {
+            context.packageManager.getPackageInfo(PACKAGE_NAME_AGENT, 0)
+                ?.versionName
+        } catch (e: PackageManager.NameNotFoundException) {
+            null
+        }
+        emit(versionName != null && !versionName.contains("stub"))
     }
 
     private val isNowPlayingAvailable = flow {
@@ -200,17 +216,26 @@ class ExperimentsViewModelImpl(
         )
     }
 
-    override val state = combine(
-        isMagicCueAvailable,
-        isNowPlayingAvailable,
+    private val packageStates = combine(
+        isAgentAvailable,
         isPhoneAvailable,
+        isMagicCueAvailable,
+        isNowPlayingAvailable
+    ) {
+        it
+    }
+
+    override val state = combine(
+        packageStates,
         propertiesRepository.state,
         phoneSettings
-    ) { magicCueAvailable, nowPlayingAvailable, isPhoneAvailable, propertiesState, phoneSettings ->
+    ) { packageStates, propertiesState, phoneSettings ->
+        val (isAgentAvailable, isPhoneAvailable, magicCueAvailable, nowPlayingAvailable) = packageStates
         State.Loaded(
             magicCueAvailable = magicCueAvailable,
             nowPlayingAvailable = nowPlayingAvailable,
             phoneAvailable = isPhoneAvailable,
+            agentAvailable = isAgentAvailable,
             phoneSettings = phoneSettings,
             propertiesState = propertiesState
         )
@@ -346,11 +371,31 @@ class ExperimentsViewModelImpl(
         }
     }
 
+    override fun onPhoneEnabledChanged(enabled: Boolean) {
+        viewModelScope.launch {
+            propertiesRepository.setPhoneEnabled(enabled)
+        }
+    }
+
+    override fun onTtsEnabledChanged(enabled: Boolean) {
+        viewModelScope.launch {
+            propertiesRepository.setTtsEnabled(enabled)
+        }
+    }
+
+    override fun onAgentEnabledChanged(enabled: Boolean) {
+        viewModelScope.launch {
+            propertiesRepository.setAgentEnabled(enabled)
+        }
+    }
+
     override fun onClearMddClicked() {
         viewModelScope.launch {
             deviceConfigPropertiesRepository.clearMdd(PACKAGE_NAME_AIC)
             deviceConfigPropertiesRepository.clearMdd(PACKAGE_NAME_PSI)
             deviceConfigPropertiesRepository.clearMdd(PACKAGE_NAME_PHONE)
+            deviceConfigPropertiesRepository.clearMdd(PACKAGE_NAME_AGENT)
+            deviceConfigPropertiesRepository.clearMdd(PACKAGE_NAME_TTS)
             events.emit(Event.MANIFESTS_PURGED)
         }
     }

--- a/app/src/main/java/com/kieronquinn/app/pcs/utils/extensions/Extensions+Pd.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/utils/extensions/Extensions+Pd.kt
@@ -23,6 +23,9 @@ val ManifestConfigConstraints.version: String?
 val ManifestConfigConstraints.deviceModel: String?
     get() = labelList.first { it.attribute == "device_model" }.value
 
+val ManifestConfigConstraints.device: String?
+    get() = labelList.firstOrNull { it.attribute == "device" }?.value
+
 val ManifestConfigConstraints.modelType: String?
     get() = labelList.first { it.attribute == "model_type" }.value
 

--- a/app/src/main/java/com/kieronquinn/app/pcs/xposed/AgentHooks.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/xposed/AgentHooks.kt
@@ -1,0 +1,41 @@
+package com.kieronquinn.app.pcs.xposed
+
+import com.kieronquinn.app.pcs.repositories.AstreaRepository.Companion.PORT_AGENT
+import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.AGENT_ENABLED
+import com.kieronquinn.app.pcs.utils.extensions.SystemProperties_getBoolean
+import de.robv.android.xposed.XposedHelpers
+import de.robv.android.xposed.callbacks.XC_LoadPackage
+import org.luckypray.dexkit.DexKitBridge
+import java.lang.reflect.Member
+
+object AgentHooks: GrpcHooks() {
+
+    override val tag = "AgentHooks"
+    override val applicationClassName =
+        "com.google.android.apps.pixel.agent.Agent_Application"
+    override val serviceClassName =
+        "com.google.android.apps.pixel.agent.model.endpoints.ModelDownloadForegroundService"
+    override val port = PORT_AGENT
+
+    override fun isEnabled(): Boolean {
+        return SystemProperties_getBoolean(AGENT_ENABLED, false)
+    }
+
+    override fun XC_LoadPackage.LoadPackageParam.getOdsConstructor(dexKit: DexKitBridge): Member? {
+        val hostLoader = dexKit.findClass {
+            matcher { usingStrings("Could not find a NameResolverProvider for %s%s") }
+        }.singleOrNull()?.let {
+            try {
+                XposedHelpers.findClass(it.name, classLoader)
+            } catch (e: XposedHelpers.ClassNotFoundError) {
+                null
+            }
+        } ?: run {
+            return null
+        }
+        return hostLoader.constructors.firstOrNull {
+            it.parameterTypes[0] == String::class.java
+        }
+    }
+
+}

--- a/app/src/main/java/com/kieronquinn/app/pcs/xposed/GrpcHooks.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/xposed/GrpcHooks.kt
@@ -23,6 +23,7 @@ import org.koin.core.context.startKoin
 import org.koin.dsl.module
 import org.luckypray.dexkit.DexKitBridge
 import retrofit2.Retrofit
+import java.lang.reflect.Member
 import java.security.cert.X509Certificate
 import javax.net.ssl.SSLSession
 
@@ -58,9 +59,10 @@ abstract class GrpcHooks: XposedHooks, KoinComponent {
 
     @CallSuper
     override fun hook(loadPackageParam: LoadPackageParam) {
-        log("Begin gRPC hooking")
         val dexKit = loadDexKit(loadPackageParam.appInfo.sourceDir)
         loadPackageParam.hookApplication()
+        if (!isEnabled()) return
+        log("Begin gRPC hooking")
         loadPackageParam.hookService()
         loadPackageParam.hookActivity()
         loadPackageParam.hookTrustManager()
@@ -68,6 +70,8 @@ abstract class GrpcHooks: XposedHooks, KoinComponent {
         loadPackageParam.hookSsl(dexKit)
         log("Finished gRPC hooking")
     }
+
+    open fun isEnabled(): Boolean = true
 
     private fun LoadPackageParam.hookApplication() {
         XposedHelpers.findAndHookMethod(
@@ -152,11 +156,7 @@ abstract class GrpcHooks: XposedHooks, KoinComponent {
         )
     }
 
-    /**
-     *  Hooks creation of gRPC client for On Device Safety (ODS) and redirects it to our own custom
-     *  localhost one.
-     */
-    private fun LoadPackageParam.hookOds(dexKit: DexKitBridge) {
+    open fun LoadPackageParam.getOdsConstructor(dexKit: DexKitBridge): Member? {
         val hostLoader = dexKit.findClass {
             matcher { usingStrings("TLS Provider failure") }
         }.singleOrNull()?.let {
@@ -166,12 +166,22 @@ abstract class GrpcHooks: XposedHooks, KoinComponent {
                 null
             }
         } ?: run {
+            return null
+        }
+        return hostLoader.getConstructor(String::class.java)
+    }
+
+    /**
+     *  Hooks creation of gRPC client for On Device Safety (ODS) and redirects it to our own custom
+     *  localhost one.
+     */
+    private fun LoadPackageParam.hookOds(dexKit: DexKitBridge) {
+        val constructor = getOdsConstructor(dexKit) ?: run {
             log("Unable to find host loader class")
             return
         }
-        XposedHelpers.findAndHookConstructor(
-            hostLoader,
-            String::class.java,
+        XposedBridge.hookMethod(
+            constructor,
             object: XC_MethodHook() {
                 override fun beforeHookedMethod(param: MethodHookParam) {
                     super.beforeHookedMethod(param)

--- a/app/src/main/java/com/kieronquinn/app/pcs/xposed/PhoneHooks.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/xposed/PhoneHooks.kt
@@ -7,9 +7,11 @@ import com.kieronquinn.app.pcs.model.phone.PhoneFlag
 import com.kieronquinn.app.pcs.model.phone.PhoneSettings
 import com.kieronquinn.app.pcs.providers.PhoneSettingsProvider
 import com.kieronquinn.app.pcs.repositories.AstreaRepository.Companion.PORT_PHONE
+import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.PHONE_ENABLED
 import com.kieronquinn.app.pcs.repositories.SettingsRepository.BeeslyRegion
 import com.kieronquinn.app.pcs.repositories.SettingsRepository.DobbyRegion
 import com.kieronquinn.app.pcs.repositories.SettingsRepository.PatrickPhase
+import com.kieronquinn.app.pcs.utils.extensions.SystemProperties_getBoolean
 import com.kieronquinn.app.pcs.utils.extensions.getKeyByValue
 import com.kieronquinn.app.pcs.utils.extensions.loadDexKit
 import com.kieronquinn.app.pcs.utils.extensions.reflectParseProto
@@ -32,6 +34,10 @@ object PhoneHooks: GrpcHooks() {
     override val port = PORT_PHONE
 
     private val flagOverrides = HashMap<PhoneFlag, Any>()
+
+    override fun isEnabled(): Boolean {
+        return SystemProperties_getBoolean(PHONE_ENABLED, false)
+    }
 
     override fun LoadPackageParam.onBeforeApplicationOnCreate(application: Application) {
         val dexKit = loadDexKit(appInfo.sourceDir)

--- a/app/src/main/java/com/kieronquinn/app/pcs/xposed/TtsHooks.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/xposed/TtsHooks.kt
@@ -1,6 +1,8 @@
 package com.kieronquinn.app.pcs.xposed
 
 import com.kieronquinn.app.pcs.repositories.AstreaRepository.Companion.PORT_TTS
+import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.TTS_ENABLED
+import com.kieronquinn.app.pcs.utils.extensions.SystemProperties_getBoolean
 
 object TtsHooks: GrpcHooks() {
 
@@ -10,5 +12,9 @@ object TtsHooks: GrpcHooks() {
     override val serviceClassName =
         "com.google.android.libraries.speech.transcription.recognition.grpc.GoogleAsrService"
     override val port = PORT_TTS
+
+    override fun isEnabled(): Boolean {
+        return SystemProperties_getBoolean(TTS_ENABLED, false)
+    }
 
 }

--- a/app/src/main/java/com/kieronquinn/app/pcs/xposed/Xposed.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/xposed/Xposed.kt
@@ -1,6 +1,7 @@
 package com.kieronquinn.app.pcs.xposed
 
 import com.kieronquinn.app.pcs.BuildConfig
+import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_AGENT
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_AS
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_PCS
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_PHONE
@@ -13,6 +14,7 @@ class Xposed: IXposedHookLoadPackage {
 
     override fun handleLoadPackage(lpparam: XC_LoadPackage.LoadPackageParam) {
         when (lpparam.packageName) {
+            "android" -> return // Don't ever hook system
             BuildConfig.APPLICATION_ID -> {
                 SelfHook.hook(lpparam)
             }
@@ -30,6 +32,9 @@ class Xposed: IXposedHookLoadPackage {
             }
             PACKAGE_NAME_AS -> {
                 AsHooks.hook(lpparam)
+            }
+            PACKAGE_NAME_AGENT -> {
+                AgentHooks.hook(lpparam)
             }
         }
         if (lpparam.packageName != BuildConfig.APPLICATION_ID) {

--- a/app/src/main/proto/manifest.proto
+++ b/app/src/main/proto/manifest.proto
@@ -12,6 +12,7 @@ message Manifests {
   repeated Manifest manifest = 1;
   repeated StaticManifest phone_manifest = 2;
   repeated StaticManifest tts_manifest = 3;
+  repeated StaticManifest agent_manifest = 4;
 }
 
 message Manifest {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -6,5 +6,6 @@
         <item>com.google.android.dialer</item>
         <item>com.google.android.apps.pixel.psi</item>
         <item>com.google.android.tts</item>
+        <item>com.google.android.apps.pixel.agent</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,6 +117,12 @@
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
 
     <string name="screen_experiments_category_advanced">Advanced</string>
+    <string name="screen_experiments_enable_phone_title">Handle Phone Manifests</string>
+    <string name="screen_experiments_enable_phone_content">Enable manifest handling for Google Phone (scam detection <b>only</b>). This is not required on most devices, so is disabled by default.</string>
+    <string name="screen_experiments_enable_tts_title">Handle TTS Manifests</string>
+    <string name="screen_experiments_enable_tts_content">Enable manifest handling for TTS (voice translate <b>only</b>). This is not required on most devices, so is disabled by default.</string>
+    <string name="screen_experiments_enable_agent_title">Handle Pixel Screenshots Manifests</string>
+    <string name="screen_experiments_enable_agent_content">Enable manifest handling for Pixel Screenshots. This is not required on most devices, so is disabled by default.</string>
     <string name="screen_experiments_clear_mdd_title">Purge Cached Manifests</string>
     <string name="screen_experiments_clear_mdd_content">Clear manifests cached by apps. This will force them to re-sync from the repository, even if up to date, and may use data to do so.</string>
     <string name="screen_experiments_clear_mdd_toast">Manifests purged</string>


### PR DESCRIPTION
- Support Pixel Screenshots own manifest requests for devices that are not passing integrity
- Manifest handling for Phone (Scam Detection), TTS (Voice Translate) and Pixel Screenshots is now optional, and disabled by default. This allows the use of the latest manifests on devices that are passing integrity
- Exclude the system from hooking for people who may erroneously hook it