### PR TITLE
1.0.5

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ private fun getLocalProperties(): Properties? {
 
 val currentLocalProperties = getLocalProperties()
 
-val tagName = "1.0.4"
-val tagCode = 104
+val tagName = "1.0.5"
+val tagCode = 105
 
 android {
     namespace = "com.kieronquinn.app.pcs"

--- a/app/src/main/java/com/kieronquinn/app/pcs/repositories/DeviceConfigPropertiesRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/repositories/DeviceConfigPropertiesRepository.kt
@@ -25,6 +25,7 @@ interface DeviceConfigPropertiesRepository {
         const val PSI_FORCE_ADMIN_ALLOWANCE_PROPERTY_NAME = "persist.psi.force_admin_allowance"
         const val PSI_CLIENT_GROUP_OVERRIDE_PROPERTY_NAME = "persist.psi.client_group_override"
         const val AS_SHOW_NOW_PLAYING_NOTIFICATION = "persist.as.show_now_playing_notification"
+        const val AS_FORCE_GSA = "persist.as.force_gsa"
         const val PHONE_ENABLED = "persist.phone.pcs_enabled"
         const val TTS_ENABLED = "persist.tts.pcs_enabled"
         const val AGENT_ENABLED = "persist.agent.pcs_enabled"

--- a/app/src/main/java/com/kieronquinn/app/pcs/repositories/PropertiesRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/repositories/PropertiesRepository.kt
@@ -1,11 +1,13 @@
 package com.kieronquinn.app.pcs.repositories
 
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_AGENT
+import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_AS
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_PHONE
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_PSI
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_TTS
 import com.kieronquinn.app.pcs.model.ClientGroupOverride
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.AGENT_ENABLED
+import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.AS_FORCE_GSA
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.AS_SHOW_NOW_PLAYING_NOTIFICATION
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.DEBUG_PROPERTY_NAME
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.PHONE_ENABLED
@@ -37,6 +39,7 @@ interface PropertiesRepository {
     suspend fun setPsiForceAccountType(enabled: Boolean)
     suspend fun setPsiForceAdminAllowance(enabled: Boolean)
     suspend fun setAsNowPlayingNotificationEnabled(enabled: Boolean)
+    suspend fun setAsForceGSAEnabled(enabled: Boolean)
     suspend fun setClientGroupOverride(override: ClientGroupOverride)
     suspend fun setPhoneEnabled(enabled: Boolean)
     suspend fun setTtsEnabled(enabled: Boolean)
@@ -49,6 +52,7 @@ interface PropertiesRepository {
         val psiForceAccountType: Boolean = false,
         val psiForceAdminAllowance: Boolean = false,
         val asNowPlayingNotificationEnabled: Boolean = false,
+        val asForceGSAEnabled: Boolean = false,
         val phoneEnabled: Boolean = false,
         val ttsEnabled: Boolean = false,
         val agentEnabled: Boolean = false,
@@ -100,6 +104,12 @@ class PropertiesRepositoryImpl(
         refreshBus.emit(System.currentTimeMillis())
     }
 
+    override suspend fun setAsForceGSAEnabled(enabled: Boolean) {
+        deviceConfigPropertiesRepository.setProperty(AS_FORCE_GSA, enabled.toString())
+        deviceConfigPropertiesRepository.forceStopPackage(PACKAGE_NAME_AS)
+        refreshBus.emit(System.currentTimeMillis())
+    }
+
     override suspend fun setClientGroupOverride(override: ClientGroupOverride) {
         deviceConfigPropertiesRepository.setProperty(PSI_CLIENT_GROUP_OVERRIDE_PROPERTY_NAME, override.name)
         refreshBus.emit(System.currentTimeMillis())
@@ -131,6 +141,7 @@ class PropertiesRepositoryImpl(
             SystemProperties_getBoolean(PSI_FORCE_ACCOUNT_TYPE_PROPERTY_NAME, false),
             SystemProperties_getBoolean(PSI_FORCE_ADMIN_ALLOWANCE_PROPERTY_NAME, false),
             SystemProperties_getBoolean(AS_SHOW_NOW_PLAYING_NOTIFICATION, false),
+            SystemProperties_getBoolean(AS_FORCE_GSA, false),
             SystemProperties_getBoolean(PHONE_ENABLED, false),
             SystemProperties_getBoolean(TTS_ENABLED, false),
             SystemProperties_getBoolean(AGENT_ENABLED, false),

--- a/app/src/main/java/com/kieronquinn/app/pcs/ui/screens/experiments/ExperimentsScreen.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/ui/screens/experiments/ExperimentsScreen.kt
@@ -67,6 +67,7 @@ private data class Interactions(
     val onPsiForceAccountTypeChanged: (Boolean) -> Unit,
     val onPsiForceAdminAllowanceChanged: (Boolean) -> Unit,
     val onAsNowPlayingChanged: (Boolean) -> Unit,
+    val onAsForceGSAChanged: (Boolean) -> Unit,
     val onClearMddClicked: () -> Unit,
     val onPhoneEnabledChanged: (Boolean) -> Unit,
     val onTtsEnabledChanged: (Boolean) -> Unit,
@@ -95,6 +96,7 @@ private data class Interactions(
             onPsiForceAccountTypeChanged = {},
             onPsiForceAdminAllowanceChanged = {},
             onAsNowPlayingChanged = {},
+            onAsForceGSAChanged = {},
             onClearMddClicked = {},
             onPhoneEnabledChanged = {},
             onTtsEnabledChanged = {},
@@ -129,6 +131,7 @@ fun ExperimentsScreen() = ProvidePreferenceLocals {
         onPsiForceAccountTypeChanged = viewModel::onPsiForceAccountTypeChanged,
         onPsiForceAdminAllowanceChanged = viewModel::onPsiForceAdminAllowanceChanged,
         onAsNowPlayingChanged = viewModel::onAsNowPlayingChanged,
+        onAsForceGSAChanged = viewModel::onAsForceGSAChanged,
         onClearMddClicked = viewModel::onClearMddClicked,
         onPhoneEnabledChanged = viewModel::onPhoneEnabledChanged,
         onTtsEnabledChanged = viewModel::onTtsEnabledChanged,
@@ -740,7 +743,7 @@ private fun LoadedContent(state: State.Loaded, interactions: Interactions) {
             preferenceCategory(
                 key = "category_as",
                 title = {
-                    Text(stringResource(R.string.screen_experiments_category_as))
+                    Text(stringResource(R.string.screen_experiments_category_now_playing))
                 }
             )
 
@@ -764,6 +767,33 @@ private fun LoadedContent(state: State.Loaded, interactions: Interactions) {
                 onValueChange = interactions.onAsNowPlayingChanged
             )
         }
+
+        preferenceCategory(
+            key = "category_aag",
+            title = {
+                Text(stringResource(R.string.screen_experiments_category_glance))
+            }
+        )
+
+        val nowPlayingShape = Shape(1, 0)
+        switchPreference(
+            modifier = Modifier
+                .padding(horizontal = 8.dp)
+                .background(color = surface, shape = nowPlayingShape)
+                .clip(nowPlayingShape),
+            value = state.propertiesState.asForceGSAEnabled,
+            key = "as_aag",
+            title = {
+                Text(
+                    text = stringResource(R.string.screen_experiments_as_force_gsa_title),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            },
+            summary = {
+                Text(text = textResource(R.string.screen_experiments_as_force_gsa_content))
+            },
+            onValueChange = interactions.onAsForceGSAChanged
+        )
 
         preferenceCategory(
             key = "category_advanced",

--- a/app/src/main/java/com/kieronquinn/app/pcs/ui/screens/experiments/ExperimentsViewModel.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/ui/screens/experiments/ExperimentsViewModel.kt
@@ -55,6 +55,7 @@ abstract class ExperimentsViewModel: ViewModel() {
     abstract fun onPsiForceAdminAllowanceChanged(enabled: Boolean)
 
     abstract fun onAsNowPlayingChanged(enabled: Boolean)
+    abstract fun onAsForceGSAChanged(enabled: Boolean)
 
     abstract fun onPhoneEnabledChanged(enabled: Boolean)
     abstract fun onTtsEnabledChanged(enabled: Boolean)
@@ -368,6 +369,12 @@ class ExperimentsViewModelImpl(
     override fun onAsNowPlayingChanged(enabled: Boolean) {
         viewModelScope.launch {
             propertiesRepository.setAsNowPlayingNotificationEnabled(enabled)
+        }
+    }
+
+    override fun onAsForceGSAChanged(enabled: Boolean) {
+        viewModelScope.launch {
+            propertiesRepository.setAsForceGSAEnabled(enabled)
         }
     }
 

--- a/app/src/main/java/com/kieronquinn/app/pcs/xposed/AsHooks.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/xposed/AsHooks.kt
@@ -1,5 +1,8 @@
 package com.kieronquinn.app.pcs.xposed
 
+import android.content.ContentResolver
+import android.provider.Settings
+import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.AS_FORCE_GSA
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.AS_SHOW_NOW_PLAYING_NOTIFICATION
 import com.kieronquinn.app.pcs.utils.extensions.SystemProperties_getBoolean
 import de.robv.android.xposed.XC_MethodHook
@@ -8,14 +11,18 @@ import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam
 import java.lang.reflect.Modifier
 
 /**
- *  Hooks ASI, intercepting the DeviceConfig call to check if New Now Playing is enabled, and
- *  selectively returns false for notifications, which allows them to show again.
+ *  Hooks ASI, optionally:
+ *  - Intercepting the DeviceConfig call to check if New Now Playing is enabled, and selectively
+ *  returns false for notifications, which allows them to show again.
+ *  - Intercepting Settings call to check if the selected search app is GSA, fakes the response
+ *  to make RemoteViews-based Smartspace components work.
  */
 object AsHooks: XposedHooks {
 
     private const val NAMESPACE_NOW_PLAYING = "systemui"
     private const val FLAG_NEW_NOW_PLAYING =
         "com.google.android.systemui.now_playing_lockscreen_extended_interaction"
+    private const val PACKAGE_NAME_GSA = "com.google.android.googlequicksearchbox"
 
     override val tag = "AsHooks"
 
@@ -35,6 +42,19 @@ object AsHooks: XposedHooks {
                         getCallingInformation(1)
                             ?.isNotificationClass(loadPackageParam.classLoader) == true) {
                         param.result = false
+                    }
+                }
+            }
+        )
+        XposedHelpers.findAndHookMethod(
+            Settings.Secure::class.java,
+            "getString",
+            ContentResolver::class.java,
+            String::class.java,
+            object: XC_MethodHook() {
+                override fun beforeHookedMethod(param: MethodHookParam) {
+                    if (SystemProperties_getBoolean(AS_FORCE_GSA, false)) {
+                        param.result = PACKAGE_NAME_GSA
                     }
                 }
             }

--- a/app/src/main/java/com/kieronquinn/app/pcs/xposed/PhoneHooks.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/xposed/PhoneHooks.kt
@@ -49,17 +49,12 @@ object PhoneHooks: GrpcHooks() {
         if (settings.patrickPhase > PatrickPhase.DISABLED) {
             hookPatrick(dexKit)
         }
+        if (settings.fermatEnabled && settings.callRecordingEnabled) {
+            hookCallRecording(dexKit)
+        }
     }
 
     private fun LoadPackageParam.hookFlagDataStore(dexKit: DexKitBridge, settings: PhoneSettings) {
-        val flagDataStore = dexKit.findClass {
-            matcher {
-                usingStrings("phenotypeServerTokens")
-            }
-        }.singleOrNull()?.getInstance(classLoader) ?: run {
-            log("Unable to find Flag DataStore")
-            return
-        }
         val flagValueHolder = dexKit.findClass {
             matcher {
                 usingStrings("null cannot be cast to non-null type T of com.google.apps.tiktok.experiments.FlagValueHolder.getProtoValue")
@@ -77,23 +72,15 @@ object PhoneHooks: GrpcHooks() {
             log("Unable to find FlagValueHolder proto method")
             return
         }
-        var hasHookedCreator = false
-        XposedHelpers.findAndHookConstructor(
-            flagDataStore,
-            Object::class.java,
-            ByteArray::class.java,
-            object: XC_MethodHook() {
-                override fun afterHookedMethod(param: MethodHookParam) {
-                    if (hasHookedCreator) return
-                    val creator = XposedHelpers
-                        .callMethod(param.args[0], "a")::class.java
-                    if (creator != java.lang.Boolean::class.java) {
-                        hasHookedCreator = true
-                        hookFlagCreator(creator, flagValueHolderClass)
-                    }
-                }
+        val flagDataStore = dexKit.findMethod {
+            matcher {
+                usingStrings("mendelPackage", "Unknown package ")
             }
-        )
+        }.singleOrNull()?.declaredClass?.getInstance(classLoader) ?: run {
+            log("Unable to find Flag DataStore")
+            return
+        }
+        hookFlagCreator(flagDataStore, flagValueHolderClass)
         hookFlagValueHolder(flagValueHolderClass, flagValueHolderProtoMethod, settings)
     }
 
@@ -107,13 +94,14 @@ object PhoneHooks: GrpcHooks() {
             log("Unable to find creator method for flags")
             return
         }
-        log("Creator method: ${creatorMethod.declaringClass.name}.${creatorMethod.name}(${creatorMethod.parameterTypes.joinToString(", ") { it.name }})")
+        log("Creator ${creator.name} method: ${creatorMethod.declaringClass.name}.${creatorMethod.name}(${creatorMethod.parameterTypes.joinToString(", ") { it.name }})")
         XposedBridge.hookMethod(creatorMethod, object: XC_MethodHook() {
             override fun afterHookedMethod(param: MethodHookParam) {
                 PhoneFlag.getOrNull(
                     param.args[0] as String,
                     param.args[1] as String
                 )?.let {
+                    log("Overriding ${it.name} -> ${flagOverrides[it]}")
                     flagOverrides[it] = param.result
                 }
             }
@@ -177,6 +165,29 @@ object PhoneHooks: GrpcHooks() {
                 objectField.set(param.args[0], true)
             }
         })
+    }
+
+    /**
+     *  Call recording is particularly annoying to get to behave when Call Notes are enabled, so
+     *  force it
+     */
+    private fun LoadPackageParam.hookCallRecording(dexKit: DexKitBridge) {
+        val callRecordingClass = dexKit.findClass {
+            matcher {
+                usingStrings("Call recording is enabled by call_recording_audio system feature")
+            }
+        }.singleOrNull()?.getInstance(classLoader) ?: run {
+            log("Unable to find Call Recording class")
+            return
+        }
+        XposedHelpers.findAndHookMethod(
+            callRecordingClass,
+            "a",
+            object: XC_MethodHook() {
+                override fun beforeHookedMethod(param: MethodHookParam) {
+                    param.result = true
+                }
+            })
     }
 
     private fun PhoneFlag.getValueOrNull(originalValue: Any?, settings: PhoneSettings): Any? {

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-ar-rSA/strings.xml
+++ b/app/src/main/res/values-ar-rSA/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-ca-rES/strings.xml
+++ b/app/src/main/res/values-ca-rES/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-da-rDK/strings.xml
+++ b/app/src/main/res/values-da-rDK/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-iw-rIL/strings.xml
+++ b/app/src/main/res/values-iw-rIL/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-no-rNO/strings.xml
+++ b/app/src/main/res/values-no-rNO/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Отключить административные ограничения</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-sr-rSP/strings.xml
+++ b/app/src/main/res/values-sr-rSP/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -105,7 +105,7 @@
     <string name="screen_experiments_psi_force_account_type_content">Allow Magic Cue to work on all Google account types</string>
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
     <string name="screen_experiments_category_advanced">Advanced</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,9 +112,13 @@
     <string name="screen_experiments_psi_force_admin_allowance_title">Disable Admin Restrictions</string>
     <string name="screen_experiments_psi_force_admin_allowance_content">Allow Magic Cue to work if your device administrator has disallowed content suggestions and content capture\n<b>Note:</b> I take no responsibility if this gets you fired, use at your own risk.</string>
 
-    <string name="screen_experiments_category_as">Now Playing</string>
+    <string name="screen_experiments_category_now_playing">Now Playing</string>
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
+
+    <string name="screen_experiments_category_glance">At a Glance</string>
+    <string name="screen_experiments_as_force_gsa_title">Disable Google App Check</string>
+    <string name="screen_experiments_as_force_gsa_content">Some At a Glance options, such as Sport and Finance, require the search box provider to be set to the Google App, enable this option to disable that check to allow them to work while other search providers are in use.</string>
 
     <string name="screen_experiments_category_advanced">Advanced</string>
     <string name="screen_experiments_enable_phone_title">Handle Phone Manifests</string>


### PR DESCRIPTION
- Fixed Google Phone Experiments
- Added new At a Glance toggle to disable the check for the selected search box in the Pixel Launcher to allow some more complex At a Glance content such as finance and sports to appear while it is set to a different search app than Google