### PR TITLE
Allow AICore to unload after inactivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ day and applying them.
 - Experiments to tweak Google Phone and Magic Cue's features
 - Enable Now Playing notification when new Now Playing is enabled, allowing Now Playing history apps to work again
 - Enable debug logging for hooked Google apps, useful for observing features such as Magic Cue
+- Optionally unload AICore's inference service after five minutes of inactivity, freeing model memory
 
 ## Frequently Asked Questions
 FAQs can be found [here](https://github.com/KieronQuinn/PublicComputeServices/blob/main/app/src/main/res/raw/faq.md). 

--- a/app/src/main/java/com/kieronquinn/app/pcs/repositories/DeviceConfigPropertiesRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/repositories/DeviceConfigPropertiesRepository.kt
@@ -26,6 +26,7 @@ interface DeviceConfigPropertiesRepository {
         const val PSI_CLIENT_GROUP_OVERRIDE_PROPERTY_NAME = "persist.psi.client_group_override"
         const val AS_SHOW_NOW_PLAYING_NOTIFICATION = "persist.as.show_now_playing_notification"
         const val AS_FORCE_GSA = "persist.as.force_gsa"
+        const val AICORE_UNLOAD_INFERENCE = "persist.aicore.unload_inference"
         const val PHONE_ENABLED = "persist.phone.pcs_enabled"
         const val TTS_ENABLED = "persist.tts.pcs_enabled"
         const val AGENT_ENABLED = "persist.agent.pcs_enabled"

--- a/app/src/main/java/com/kieronquinn/app/pcs/repositories/PropertiesRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/repositories/PropertiesRepository.kt
@@ -1,12 +1,14 @@
 package com.kieronquinn.app.pcs.repositories
 
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_AGENT
+import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_AIC
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_AS
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_PHONE
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_PSI
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_TTS
 import com.kieronquinn.app.pcs.model.ClientGroupOverride
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.AGENT_ENABLED
+import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.AICORE_UNLOAD_INFERENCE
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.AS_FORCE_GSA
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.AS_SHOW_NOW_PLAYING_NOTIFICATION
 import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.DEBUG_PROPERTY_NAME
@@ -40,6 +42,7 @@ interface PropertiesRepository {
     suspend fun setPsiForceAdminAllowance(enabled: Boolean)
     suspend fun setAsNowPlayingNotificationEnabled(enabled: Boolean)
     suspend fun setAsForceGSAEnabled(enabled: Boolean)
+    suspend fun setAiCoreUnloadInference(enabled: Boolean)
     suspend fun setClientGroupOverride(override: ClientGroupOverride)
     suspend fun setPhoneEnabled(enabled: Boolean)
     suspend fun setTtsEnabled(enabled: Boolean)
@@ -53,6 +56,7 @@ interface PropertiesRepository {
         val psiForceAdminAllowance: Boolean = false,
         val asNowPlayingNotificationEnabled: Boolean = false,
         val asForceGSAEnabled: Boolean = false,
+        val aicoreUnloadInference: Boolean = false,
         val phoneEnabled: Boolean = false,
         val ttsEnabled: Boolean = false,
         val agentEnabled: Boolean = false,
@@ -110,6 +114,12 @@ class PropertiesRepositoryImpl(
         refreshBus.emit(System.currentTimeMillis())
     }
 
+    override suspend fun setAiCoreUnloadInference(enabled: Boolean) {
+        deviceConfigPropertiesRepository.setProperty(AICORE_UNLOAD_INFERENCE, enabled.toString())
+        deviceConfigPropertiesRepository.forceStopPackage(PACKAGE_NAME_AIC)
+        refreshBus.emit(System.currentTimeMillis())
+    }
+
     override suspend fun setClientGroupOverride(override: ClientGroupOverride) {
         deviceConfigPropertiesRepository.setProperty(PSI_CLIENT_GROUP_OVERRIDE_PROPERTY_NAME, override.name)
         refreshBus.emit(System.currentTimeMillis())
@@ -142,6 +152,7 @@ class PropertiesRepositoryImpl(
             SystemProperties_getBoolean(PSI_FORCE_ADMIN_ALLOWANCE_PROPERTY_NAME, false),
             SystemProperties_getBoolean(AS_SHOW_NOW_PLAYING_NOTIFICATION, false),
             SystemProperties_getBoolean(AS_FORCE_GSA, false),
+            SystemProperties_getBoolean(AICORE_UNLOAD_INFERENCE, false),
             SystemProperties_getBoolean(PHONE_ENABLED, false),
             SystemProperties_getBoolean(TTS_ENABLED, false),
             SystemProperties_getBoolean(AGENT_ENABLED, false),

--- a/app/src/main/java/com/kieronquinn/app/pcs/ui/screens/experiments/ExperimentsScreen.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/ui/screens/experiments/ExperimentsScreen.kt
@@ -68,6 +68,7 @@ private data class Interactions(
     val onPsiForceAdminAllowanceChanged: (Boolean) -> Unit,
     val onAsNowPlayingChanged: (Boolean) -> Unit,
     val onAsForceGSAChanged: (Boolean) -> Unit,
+    val onAiCoreUnloadInferenceChanged: (Boolean) -> Unit,
     val onClearMddClicked: () -> Unit,
     val onPhoneEnabledChanged: (Boolean) -> Unit,
     val onTtsEnabledChanged: (Boolean) -> Unit,
@@ -97,6 +98,7 @@ private data class Interactions(
             onPsiForceAdminAllowanceChanged = {},
             onAsNowPlayingChanged = {},
             onAsForceGSAChanged = {},
+            onAiCoreUnloadInferenceChanged = {},
             onClearMddClicked = {},
             onPhoneEnabledChanged = {},
             onTtsEnabledChanged = {},
@@ -132,6 +134,7 @@ fun ExperimentsScreen() = ProvidePreferenceLocals {
         onPsiForceAdminAllowanceChanged = viewModel::onPsiForceAdminAllowanceChanged,
         onAsNowPlayingChanged = viewModel::onAsNowPlayingChanged,
         onAsForceGSAChanged = viewModel::onAsForceGSAChanged,
+        onAiCoreUnloadInferenceChanged = viewModel::onAiCoreUnloadInferenceChanged,
         onClearMddClicked = viewModel::onClearMddClicked,
         onPhoneEnabledChanged = viewModel::onPhoneEnabledChanged,
         onTtsEnabledChanged = viewModel::onTtsEnabledChanged,
@@ -768,6 +771,39 @@ private fun LoadedContent(state: State.Loaded, interactions: Interactions) {
             )
         }
 
+        if (state.aicoreAvailable) {
+            preferenceCategory(
+                key = "category_aicore",
+                title = {
+                    Text(stringResource(R.string.screen_experiments_category_aicore))
+                }
+            )
+
+            val aicoreShape = Shape(1, 0)
+            switchPreference(
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .background(color = surface, shape = aicoreShape)
+                    .clip(aicoreShape),
+                value = state.propertiesState.aicoreUnloadInference,
+                key = "aicore_unload_inference",
+                title = {
+                    Text(
+                        text = stringResource(
+                            R.string.screen_experiments_aicore_unload_inference_title
+                        ),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                },
+                summary = {
+                    Text(text = textResource(
+                        R.string.screen_experiments_aicore_unload_inference_content
+                    ))
+                },
+                onValueChange = interactions.onAiCoreUnloadInferenceChanged
+            )
+        }
+
         preferenceCategory(
             key = "category_aag",
             title = {
@@ -967,6 +1003,7 @@ private fun ContentPreviewLight() {
         val state = State.Loaded(
             magicCueAvailable = true,
             nowPlayingAvailable = true,
+            aicoreAvailable = true,
             phoneAvailable = true,
             agentAvailable = true,
             phoneSettings = PhoneSettings(

--- a/app/src/main/java/com/kieronquinn/app/pcs/ui/screens/experiments/ExperimentsViewModel.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/ui/screens/experiments/ExperimentsViewModel.kt
@@ -56,6 +56,7 @@ abstract class ExperimentsViewModel: ViewModel() {
 
     abstract fun onAsNowPlayingChanged(enabled: Boolean)
     abstract fun onAsForceGSAChanged(enabled: Boolean)
+    abstract fun onAiCoreUnloadInferenceChanged(enabled: Boolean)
 
     abstract fun onPhoneEnabledChanged(enabled: Boolean)
     abstract fun onTtsEnabledChanged(enabled: Boolean)
@@ -69,6 +70,7 @@ abstract class ExperimentsViewModel: ViewModel() {
         data class Loaded(
             val magicCueAvailable: Boolean,
             val nowPlayingAvailable: Boolean,
+            val aicoreAvailable: Boolean,
             val phoneAvailable: Boolean,
             val agentAvailable: Boolean,
             val phoneSettings: PhoneSettings,
@@ -138,6 +140,15 @@ class ExperimentsViewModelImpl(
             null
         }
         emit(versionName != null && !versionName.contains("stub"))
+    }
+
+    private val isAiCoreAvailable = flow {
+        try {
+            context.packageManager.getPackageInfo(PACKAGE_NAME_AIC, 0)
+            emit(true)
+        } catch (e: PackageManager.NameNotFoundException) {
+            emit(false)
+        }
     }
 
     private val isNowPlayingAvailable = flow {
@@ -221,7 +232,8 @@ class ExperimentsViewModelImpl(
         isAgentAvailable,
         isPhoneAvailable,
         isMagicCueAvailable,
-        isNowPlayingAvailable
+        isNowPlayingAvailable,
+        isAiCoreAvailable
     ) {
         it
     }
@@ -231,10 +243,12 @@ class ExperimentsViewModelImpl(
         propertiesRepository.state,
         phoneSettings
     ) { packageStates, propertiesState, phoneSettings ->
-        val (isAgentAvailable, isPhoneAvailable, magicCueAvailable, nowPlayingAvailable) = packageStates
+        val (isAgentAvailable, isPhoneAvailable, magicCueAvailable, nowPlayingAvailable,
+            isAiCoreAvailable) = packageStates
         State.Loaded(
             magicCueAvailable = magicCueAvailable,
             nowPlayingAvailable = nowPlayingAvailable,
+            aicoreAvailable = isAiCoreAvailable,
             phoneAvailable = isPhoneAvailable,
             agentAvailable = isAgentAvailable,
             phoneSettings = phoneSettings,
@@ -375,6 +389,12 @@ class ExperimentsViewModelImpl(
     override fun onAsForceGSAChanged(enabled: Boolean) {
         viewModelScope.launch {
             propertiesRepository.setAsForceGSAEnabled(enabled)
+        }
+    }
+
+    override fun onAiCoreUnloadInferenceChanged(enabled: Boolean) {
+        viewModelScope.launch {
+            propertiesRepository.setAiCoreUnloadInference(enabled)
         }
     }
 

--- a/app/src/main/java/com/kieronquinn/app/pcs/xposed/AiCoreHooks.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/xposed/AiCoreHooks.kt
@@ -1,0 +1,80 @@
+package com.kieronquinn.app.pcs.xposed
+
+import android.content.ContentResolver
+import android.content.Context
+import android.provider.Settings
+import com.kieronquinn.app.pcs.repositories.DeviceConfigPropertiesRepository.Companion.AICORE_UNLOAD_INFERENCE
+import com.kieronquinn.app.pcs.utils.extensions.SystemProperties_getBoolean
+import com.kieronquinn.app.pcs.utils.extensions.loadDexKit
+import de.robv.android.xposed.XC_MethodHook
+import de.robv.android.xposed.XposedBridge
+import de.robv.android.xposed.XposedHelpers
+import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam
+
+/**
+ * Prevents AICore from keeping the on-device inference service bound indefinitely after use. AICore
+ * normally writes -1 to disable the framework's idle unbind timeout, then preloads the model again
+ * when the inference service disconnects.
+ */
+object AiCoreHooks: XposedHooks {
+
+    private const val SETTING_INFERENCE_SERVICE_UNBIND_TIMEOUT =
+        "on_device_inference_unbind_timeout_ms"
+    private const val INFERENCE_SERVICE_UNBIND_TIMEOUT_MILLIS = 5 * 60 * 1000L
+    private const val PERSISTENT_MODE_PRELOAD_LOG =
+        "Persistent mode is enabled. Scheduling preload model"
+
+    @Volatile
+    private var changedInferenceServiceUnbindTimeout = false
+
+    override val tag = "AiCoreHooks"
+
+    override fun hook(loadPackageParam: LoadPackageParam) {
+        if (!SystemProperties_getBoolean(AICORE_UNLOAD_INFERENCE, false)) return
+        val onInferenceServiceDisconnected = loadDexKit(loadPackageParam.appInfo.sourceDir)
+            .findClass {
+                matcher { usingStrings(PERSISTENT_MODE_PRELOAD_LOG) }
+            }.singleOrNull()?.findMethod {
+                matcher { usingStrings(PERSISTENT_MODE_PRELOAD_LOG) }
+            }?.singleOrNull()?.getMethodInstance(loadPackageParam.classLoader)?.takeIf {
+                it.name == "onInferenceServiceDisconnected" &&
+                        it.parameterCount == 0 && it.returnType == Void.TYPE
+            } ?: run {
+                log("Unable to find supported inference service disconnect callback")
+                return
+            }
+        XposedHelpers.findAndHookMethod(
+            Settings.Secure::class.java,
+            "putLong",
+            ContentResolver::class.java,
+            String::class.java,
+            Long::class.java,
+            object: XC_MethodHook() {
+                override fun beforeHookedMethod(param: MethodHookParam) {
+                    if (param.args[1] == SETTING_INFERENCE_SERVICE_UNBIND_TIMEOUT &&
+                        param.args[2] == -1L) {
+                        param.args[2] = INFERENCE_SERVICE_UNBIND_TIMEOUT_MILLIS
+                        changedInferenceServiceUnbindTimeout = true
+                        log("Changed inference service unbind timeout to " +
+                            "$INFERENCE_SERVICE_UNBIND_TIMEOUT_MILLIS ms")
+                    }
+                }
+            }
+        )
+        XposedBridge.hookMethod(
+            onInferenceServiceDisconnected,
+            object: XC_MethodHook() {
+                override fun beforeHookedMethod(param: MethodHookParam) {
+                    if (changedInferenceServiceUnbindTimeout && Settings.Secure.getLong(
+                            (param.thisObject as Context).contentResolver,
+                            SETTING_INFERENCE_SERVICE_UNBIND_TIMEOUT, -1L
+                        ) == INFERENCE_SERVICE_UNBIND_TIMEOUT_MILLIS) {
+                        param.result = null
+                        log("Prevented inference model preload after idle disconnect")
+                    }
+                }
+            }
+        )
+    }
+
+}

--- a/app/src/main/java/com/kieronquinn/app/pcs/xposed/Xposed.kt
+++ b/app/src/main/java/com/kieronquinn/app/pcs/xposed/Xposed.kt
@@ -2,6 +2,7 @@ package com.kieronquinn.app.pcs.xposed
 
 import com.kieronquinn.app.pcs.BuildConfig
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_AGENT
+import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_AIC
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_AS
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_PCS
 import com.kieronquinn.app.pcs.PcsApplication.Companion.PACKAGE_NAME_PHONE
@@ -35,6 +36,9 @@ class Xposed: IXposedHookLoadPackage {
             }
             PACKAGE_NAME_AGENT -> {
                 AgentHooks.hook(lpparam)
+            }
+            PACKAGE_NAME_AIC -> {
+                AiCoreHooks.hook(lpparam)
             }
         }
         if (lpparam.packageName != BuildConfig.APPLICATION_ID) {

--- a/app/src/main/res/raw/faq.md
+++ b/app/src/main/res/raw/faq.md
@@ -81,6 +81,13 @@ part of the app's package name, in all caps. For example, to follow the progress
 models, enable debug logging, make sure *Device Intelligence* is hooked, and monitor the log with 
 the tag "PSI".
 
+## Can Public Compute Services reduce AICore's memory use?
+
+Enable **Unload AI models when idle** on the Experiments screen. Make sure
+`com.google.android.aicore` is enabled in the module's LSPosed scope, then restart AICore or reboot.
+The inference model will unload after five minutes without a request and load again when needed, so
+the first AI request after unloading may take longer.
+
 ## Models aren't downloading!
 
 There's a few possible causes for this:

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -7,5 +7,6 @@
         <item>com.google.android.apps.pixel.psi</item>
         <item>com.google.android.tts</item>
         <item>com.google.android.apps.pixel.agent</item>
+        <item>com.google.android.aicore</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,10 @@
     <string name="screen_experiments_as_show_notification_title">Now Playing Notification</string>
     <string name="screen_experiments_as_show_notification_content">Show notification of currently detected song, which was removed with new Now Playing. This will also make Now Playing History apps work again.</string>
 
+    <string name="screen_experiments_category_aicore">AICore</string>
+    <string name="screen_experiments_aicore_unload_inference_title">Unload AI models when idle</string>
+    <string name="screen_experiments_aicore_unload_inference_content">Unload on-device AI models after five minutes of inactivity to free memory. The first request after unloading may take longer.</string>
+
     <string name="screen_experiments_category_glance">At a Glance</string>
     <string name="screen_experiments_as_force_gsa_title">Disable Google App Check</string>
     <string name="screen_experiments_as_force_gsa_content">Some At a Glance options, such as Sport and Finance, require the search box provider to be set to the Google App, enable this option to disable that check to allow them to work while other search providers are in use.</string>


### PR DESCRIPTION
## Summary

- Add an opt-in experiment that unloads AICore's inference model after five idle minutes
- Prevent persistent mode from immediately preloading the model after an idle disconnect
- Add AICore to the recommended LSPosed scope and document the cold-start tradeoff

## Compatibility

The hook validates the currently supported AICore callback before changing the framework timeout.
Unsupported AICore versions therefore retain their original behavior.

## Validation

- `bash ./gradlew :app:compileDebugKotlin`
- Verified on a rooted test Pixel device (Android 17) that inference completes normally, the isolated service unloads
  after five idle minutes, and the service can reconnect for later requests
